### PR TITLE
baseline: sync current state and docs (PR template, STATE, diagrams/src)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## 目的 (Purpose)
+- Why:
+- What:
+
+## 変更点 (Changes)
+- [ ]
+- [ ]
+
+## 動作確認 (How to verify)
+- [ ] `make healthcheck` → ✅ Green（Run URL: ）
+- [ ] `pytest -q` → ✅ Green
+- [ ] `python cli.py <obj> "テスト"` 実行後に `objectives/<obj>/logs/*.jsonl` が追記される
+- [ ] `objectives/<obj>/memory.json` 先頭に要約（≤400字）が追加される
+
+## Evidence（証拠）
+- CI Run URL:
+- Artifacts (reports/*.json):
+- スクリーンショット:
+
+## 影響範囲 (Impact)
+- [ ] CLI / Streamlit UI
+- [ ] src/core/logging.py
+- [ ] src/core/summary.py
+- [ ] schema/*.json
+- [ ] STATE/current_state.md
+
+## リスク・確認事項 (Risks)
+- [ ] スキーマ互換（summary.v1.json / memory.v1.json）
+- [ ] 冪等性（重複抑止）
+- [ ] 秘密情報なし
+
+## 関連 Issue
+Fixes #
+
+## チェックリスト (Reviewer ready)
+- [ ] 説明が埋まっている
+- [ ] テストを追加／更新した
+- [ ] STATE/current_state.md を更新した

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+diagrams/export/

--- a/STATE/current_state.md
+++ b/STATE/current_state.md
@@ -1,0 +1,25 @@
+# current_state.md
+
+## C（現在地）
+- Step-A-1
+- 運用基盤:
+  - PRT: done
+  - DoD: done
+  - STATE_INIT: todo
+  - ARTS: todo
+- 実装:
+  - LOG: todo
+  - SUM: todo
+  - TST: todo
+
+## G（ゴール）
+- P0-2 緑化（要約Pipeline完成）
+
+## δ（差分）
+- 残り運用基盤: STATE_INIT, ARTS
+- 実装: LOG, SUM, TST
+
+## 次アクション
+1. このファイルをSTATE/に保存し、初回コミット
+2. ARTS（CIでreports/*.json保存）を設定
+3. LOG→SUM→TSTの順に実装

--- a/diagrams/src/ops_single_source_of_truth_v1.md
+++ b/diagrams/src/ops_single_source_of_truth_v1.md
@@ -1,0 +1,108 @@
+```mermaid
+flowchart LR
+  %% ==== Environments ====
+  subgraph L["Local Dev: vpm-mini（ローカル）"]
+    CLI["CLI / Streamlit"]
+    LOG["append_chatlog() → logs/*.jsonl"]
+    SUM["summary.run() → memory.json（先頭追記）"]
+    TST["pytest / make healthcheck（ローカル）"]
+    CLI --> LOG --> SUM --> TST
+  end
+
+  subgraph R["GitHub Repo（唯一の真実）"]
+    BR["Branch / PR（テンプレ適用）"]
+    ISS["Issue（DoD付き）"]
+    ST["STATE/current_state.md（C・G・δ）"]
+    BR -. "links" .- ISS
+    BR -. "updates" .- ST
+  end
+
+  subgraph C["GitHub Actions（CI／必須チェック）"]
+    HC["healthcheck（pytest）"]
+    ART["Artifacts: reports/*.json"]
+    STAT["Status Check（Green/Red）"]
+    HC --> ART --> STAT
+  end
+
+  subgraph P["Artifacts／Evidence（証拠保管）"]
+    COV["coverage.json（被覆ギャップ0）"]
+    LAG["lag.json（p50／p95）"]
+    QLT["quality.json（≤400字／JSON妥当）"]
+  end
+
+  subgraph CHAT["Chat（あなた ↔ Assistant）"]
+    CK["[Check-in]：Repo／Branch／PR／Run／Evidence／Next"]
+    DEC["合意：次アクション（誰が／どこで／何を）"]
+    CK --> DEC
+  end
+
+  %% ==== Main flows ====
+  L -->|push| BR
+  BR --> HC
+  STAT --> BR
+  ART --> COV
+  ART --> LAG
+  ART --> QLT
+  CK -. "参照" .- BR
+  CK -. "参照" .- COV
+  DEC --> BR
+
+  %% ==== Initial Setup (one-time, 運用基盤4つを含む) ====
+  subgraph INIT["初期準備（1回だけ）"]
+    PRT[".github/pull_request_template.md"]
+    DoD["Issue用DoDテンプレ（プロジェクトノート）"]
+    STATE_INIT["STATE/current_state.md 作成（C・G・δ）"]
+    ARTS["CIで reports/*.json をアーティファクト保存（workflow追加）"]
+    PRT --> DoD --> STATE_INIT --> ARTS
+  end
+  %% connect setup outputs to real nodes (not subgraph ids)
+  PRT -. "使う" .- BR
+  DoD -. "参照" .- ISS
+  STATE_INIT -. "更新" .- ST
+  ARTS --> ART
+
+  %% ==== Daily Ops (each change) ====
+  subgraph OPS["運用時（毎回）"]
+    O1["1. ローカルで実装 → make healthcheck（任意）"]
+    O2["2. PR作成（テンプレ／DoD記入）"]
+    O3["3. CI実行 → Artifacts確認"]
+    O4["4. Chatで[Check-in]共有 → 合意"]
+    O5["5. GreenならMerge → STATE更新"]
+    O1 --> O2 --> O3 --> O4 --> O5
+  end
+  TST --> O1
+  O2 --> BR
+  O3 --> HC
+  O4 --> CK
+  O5 --> ST
+
+  %% ==== Legend (status colors) ====
+  classDef done fill:#B2F2BB,stroke:#009B4D,color:#0B4725;
+  classDef wip fill:#FFF3BF,stroke:#E6A700,color:#7A5E00;
+  classDef todo fill:#E9ECEF,stroke:#ADB5BD,color:#495057;
+
+  %% ==== 初期ステータス（必要に応じて編集してね） ====
+  %% Local: CLIは既存 → done。ログ保存/要約/ローカルテストはこれから → todo。
+  class CLI done
+  class LOG,SUM,TST todo
+
+  %% Repo: PR運用はwip、Issue/STATEはこれから → todo。
+  class BR wip
+  class ISS,ST todo
+
+  %% CI: まだ最小構成を入れる前 → todo。
+  class HC,ART,STAT todo
+
+  %% Artifacts: これから → todo。
+  class COV,LAG,QLT todo
+
+  %% Chat運用：Check-in/合意は運用開始段階 → wip
+  class CK wip
+  class DEC wip
+
+  %% 初期準備（運用基盤4つ）：まずは todo
+  class PRT,DoD,STATE_INIT,ARTS todo
+
+  %% 運用フロー：常に繰り返すため wip。
+  class O1,O2,O3,O4,O5 wip
+```

--- a/diagrams/src/summary_pipeline_detail_v1.md
+++ b/diagrams/src/summary_pipeline_detail_v1.md
@@ -1,0 +1,60 @@
+```mermaid
+flowchart LR
+  %% ========= Entry (Conversation Logs) =========
+  subgraph ENTRY["入力（会話ログ）"]
+    UI["Chat UI / CLI"]
+    ENV["Message Envelope v1\n{source, role, created_at, text, meta...}"]
+    UI --> ENV
+  end
+
+  %% ========= Trigger Layer =========
+  subgraph TRIG["要約トリガ（漏れ防止の多重条件）"]
+    EV["イベント: 新規発話\n(debounce 5–10s)"]
+    TH["閾値: 未処理バッファ ≥ 1000 tok"]
+    IDLE["アイドル: 無発話 5 min"]
+    DAILY["日次整合: 直近24h 再スイープ"]
+  end
+  ENV --> TRIG
+
+  %% ========= Windowing =========
+  subgraph WIN["ウィンドウ処理"]
+    WCFG["窓=1000 tok / ストライド=500\n(50% overlap)"]
+    WM["ウォーターマーク\n(msg_id, tok_offset)"]
+    HASH["content-hash による重複抑止"]
+  end
+  TRIG --> WIN
+  WIN -->|チャンク列| ROUTER
+
+  %% ========= Routing & Summarization =========
+  subgraph SUM["要約ルータ／アダプタ"]
+    DET["Detector\n(mime/ヒューリスティクス)"]
+    ROUTER["Router\n(確信度で器を選択 / 汎用にフォールバック)"]
+    CONV["@conversation_summarizer\n<=400字 / 重要点抽出"]
+    GEN["@generic_summarizer"]
+    DET --> ROUTER
+    ROUTER -->|conv| CONV
+    ROUTER -->|fallback| GEN
+  end
+
+  %% ========= Validation & Persist =========
+  subgraph OUT["出力・検証・保存"]
+    SCHEMA["summary.schema.json v1\n(JSON Schema Validate)"]
+    MEM["memory.json\n(先頭追記: {window_start/end, stride, wm, hash, text})"]
+    SCHEMA -.-> MEM
+  end
+  SUM --> OUT
+
+  %% ========= Downstream =========
+  subgraph NORM["正規化 → Vector → EG‑Space"]
+    META["Metadata 付与\n(Recency, Role, Trust...)"]
+    EMBED["Embed 768D"]
+    VEC["Vector DB (pgvector)"]
+    CGH["EG‑Space: C/G/H 計算\n(C=直近24hの加重平均)"]
+    META --> EMBED --> VEC --> CGH
+  end
+  OUT --> META
+
+  %% ========= Notes =========
+  classDef box fill:#fff,stroke:#333,stroke-width:1px,color:#111;
+  class UI,ENV,EV,TH,IDLE,DAILY,WCFG,WM,HASH,DET,ROUTER,CONV,GEN,SCHEMA,MEM,META,EMBED,VEC,CGH box;
+```


### PR DESCRIPTION
## 概要
現時点のローカル変更を main に正式反映するベースライン同期PRです。
今後の目的別PR（運用基盤・要約Pipeline）を小さく切るための土台。

## 含まれる変更
- .github/pull_request_template.md の追加
- STATE/current_state.md の初期版
- diagrams/src/*.md の追加（ソースのみ。export SVGは .gitignore）

## 期待する効果
- main が現状と一致し、以後の差分が明確化
- 進捗図の PRT / STATE_INIT を緑にできる
