### PR TITLE
chore: add CI workflow for artifacts storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test-and-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Prepare reports/*
+        run: |
+          mkdir -p reports
+          echo '{"status":"ci-boot"}' > reports/quality.json
+          echo '{"covered":0}'        > reports/coverage.json
+          echo '{"p50_ms":0,"p95_ms":0}' > reports/lag.json
+      - name: Upload reports as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports
+          path: reports/*.json
+          if-no-files-found: error

--- a/STATE/current_state.md
+++ b/STATE/current_state.md
@@ -21,5 +21,5 @@
 
 ## 次アクション
 1. このファイルをSTATE/に保存し、初回コミット
-2. ARTS（CIでreports/*.json保存）を設定
+2. ARTS（CIでreports/*.json保存）を設定 - CI setup PR opened
 3. LOG→SUM→TSTの順に実装

--- a/diagrams/src/ops_single_source_of_truth_v1.md
+++ b/diagrams/src/ops_single_source_of_truth_v1.md
@@ -49,10 +49,10 @@ flowchart LR
 
   %% ==== Initial Setup (one-time, 運用基盤4つを含む) ====
   subgraph INIT["初期準備（1回だけ）"]
-    PRT[".github/pull_request_template.md"]
-    DoD["Issue用DoDテンプレ（プロジェクトノート）"]
-    STATE_INIT["STATE/current_state.md 作成（C・G・δ）"]
-    ARTS["CIで reports/*.json をアーティファクト保存（workflow追加）"]
+    PRT["PRT · .github/pull_request_template.md"]
+    DoD["DoD · Issue用DoDテンプレ（プロジェクトノート）"]
+    STATE_INIT["STATE_INIT · STATE/current_state.md 作成（C・G・δ）"]
+    ARTS["ARTS · CIで reports/*.json をアーティファクト保存（workflow追加）"]
     PRT --> DoD --> STATE_INIT --> ARTS
   end
   %% connect setup outputs to real nodes (not subgraph ids)
@@ -81,28 +81,24 @@ flowchart LR
   classDef wip fill:#FFF3BF,stroke:#E6A700,color:#7A5E00;
   classDef todo fill:#E9ECEF,stroke:#ADB5BD,color:#495057;
 
-  %% ==== 初期ステータス（必要に応じて編集してね） ====
-  %% Local: CLIは既存 → done。ログ保存/要約/ローカルテストはこれから → todo。
+  %% ==== 現状の進捗反映 ====
   class CLI done
   class LOG,SUM,TST todo
 
-  %% Repo: PR運用はwip、Issue/STATEはこれから → todo。
   class BR wip
   class ISS,ST todo
 
-  %% CI: まだ最小構成を入れる前 → todo。
   class HC,ART,STAT todo
 
-  %% Artifacts: これから → todo。
   class COV,LAG,QLT todo
 
-  %% Chat運用：Check-in/合意は運用開始段階 → wip
   class CK wip
   class DEC wip
 
-  %% 初期準備（運用基盤4つ）：まずは todo
-  class PRT,DoD,STATE_INIT,ARTS todo
+  class PRT done
+  class DoD todo
+  class STATE_INIT done
+  class ARTS wip
 
-  %% 運用フロー：常に繰り返すため wip。
   class O1,O2,O3,O4,O5 wip
 ```


### PR DESCRIPTION
## 目的 (Purpose)
- Why:
- What:

## 変更点 (Changes)
- [ ]
- [ ]

## 動作確認 (How to verify)
- [ ] `make healthcheck` → ✅ Green（Run URL: ）
- [ ] `pytest -q` → ✅ Green
- [ ] `python cli.py <obj> "テスト"` 実行後に `objectives/<obj>/logs/*.jsonl` が追記される
- [ ] `objectives/<obj>/memory.json` 先頭に要約（≤400字）が追加される

## Evidence（証拠）
- CI Run URL:https://github.com/HirakuArai/vpm-mini/actions/runs/16866720632/job/47774604019?pr=8
- Artifacts (reports/*.json):https://github.com/HirakuArai/vpm-mini/suites/43253214875/artifacts/3730135516
- スクリーンショット:

## 影響範囲 (Impact)
- [ ] CLI / Streamlit UI
- [ ] src/core/logging.py
- [ ] src/core/summary.py
- [ ] schema/*.json
- [ ] STATE/current_state.md

## リスク・確認事項 (Risks)
- [ ] スキーマ互換（summary.v1.json / memory.v1.json）
- [ ] 冪等性（重複抑止）
- [ ] 秘密情報なし

## 関連 Issue
Fixes #

## 完了条件（DoD）
- [DoDリンク](https://github.com/users/HirakuArai/projects/1?pane=issue&itemId=123637605)

## チェックリスト (Reviewer ready)
- [ ] 説明が埋まっている
- [ ] テストを追加／更新した
- [ ] STATE/current_state.md を更新した
