### PR TITLE
feat(log): append_chatlog() -> logs/*.jsonl (schema v1)

### DIFF
--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,0 +1,51 @@
+# tests/test_logs.py
+import json
+from datetime import datetime
+
+from vpm_mini.logs import append_turn, append_chatlog, read_logs
+
+
+def test_append_turn(tmp_path, monkeypatch):
+    """Test appending a single turn to log file."""
+    monkeypatch.chdir(tmp_path)
+
+    ts = datetime.now().timestamp()
+    log_path = append_turn(
+        ts=ts,
+        role="user",
+        text="テストメッセージ",
+        session_id="S:2025-08-17#1",
+        refs=["file:test.md"],
+    )
+
+    assert log_path.exists()
+
+    # Read and verify
+    with open(log_path, "r", encoding="utf-8") as f:
+        line = f.readline()
+        event = json.loads(line)
+
+    assert event["ts"] == ts
+    assert event["role"] == "user"
+    assert event["text"] == "テストメッセージ"
+    assert event["session_id"] == "S:2025-08-17#1"
+    assert event["refs"] == ["file:test.md"]
+    assert event["meta"]["lang"] == "ja"
+
+
+def test_append_chatlog(tmp_path, monkeypatch):
+    """Test appending multiple turns."""
+    monkeypatch.chdir(tmp_path)
+
+    turns = [
+        {"role": "user", "text": "質問1"},
+        {"role": "assistant", "text": "回答1"},
+    ]
+
+    log_path = append_chatlog(turns, "S:2025-08-17#2")
+
+    events = read_logs(log_path)
+    assert len(events) == 2
+    assert events[0]["text"] == "質問1"
+    assert events[1]["text"] == "回答1"
+    assert all(e["session_id"] == "S:2025-08-17#2" for e in events)

--- a/vpm_mini/logs.py
+++ b/vpm_mini/logs.py
@@ -1,0 +1,81 @@
+# vpm_mini/logs.py
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+
+def append_turn(
+    ts: float,
+    role: str,
+    text: str,
+    session_id: str,
+    refs: list[str] | None = None,
+) -> Path:
+    """Append a single turn to today's log file."""
+    log_dir = Path("logs")
+    log_dir.mkdir(exist_ok=True)
+
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    log_path = log_dir / f"{date_str}.jsonl"
+
+    turn = {
+        "ts": ts,
+        "session_id": session_id,
+        "role": role,
+        "text": text,
+        "refs": refs or [],
+        "meta": {"lang": "ja"},
+    }
+
+    with open(log_path, "a", encoding="utf-8") as f:
+        json.dump(turn, f, ensure_ascii=False)
+        f.write("\n")
+
+    return log_path
+
+
+def append_chatlog(turns: list[dict], session_id: str) -> Path:
+    """Append multiple turns to today's log file."""
+    log_dir = Path("logs")
+    log_dir.mkdir(exist_ok=True)
+
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    log_path = log_dir / f"{date_str}.jsonl"
+
+    with open(log_path, "a", encoding="utf-8") as f:
+        for turn in turns:
+            # Ensure required fields
+            event = {
+                "ts": turn.get("ts", datetime.now().timestamp()),
+                "session_id": session_id,
+                "role": turn.get("role", "user"),
+                "text": turn.get("text", ""),
+                "refs": turn.get("refs", []),
+                "meta": turn.get("meta", {"lang": "ja"}),
+            }
+            json.dump(event, f, ensure_ascii=False)
+            f.write("\n")
+
+    return log_path
+
+
+def read_logs(log_path: str | Path) -> list[dict]:
+    """Read all events from a JSONL log file."""
+    events = []
+    with open(log_path, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                events.append(json.loads(line))
+    return events
+
+
+def extract_text_from_logs(log_path: str | Path) -> str:
+    """Extract and concatenate all text from a log file."""
+    events = read_logs(log_path)
+    texts = []
+    for event in events:
+        if event.get("text"):
+            texts.append(event["text"])
+    return "\n\n".join(texts)


### PR DESCRIPTION
## What
- Add chat log JSONL writer: `append_turn`, `append_chatlog`
- Allow `vpm_mini.digest` to read `--from-logs`

## DoD
- JSONL file created: `logs/YYYY-MM-DD.jsonl`
- Each line has keys: ts, session_id, role, text, refs, meta
- pytest added and passing