### PR TITLE
chore(ci): add healthcheck (pytest + optional diagram export)

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -1,0 +1,16 @@
+name: healthcheck
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run healthcheck
+        run: |
+          bash scripts/healthcheck.sh

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -4,13 +4,16 @@ on:
   push:
     branches: [ main ]
 jobs:
-  test:
+  healthcheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Run healthcheck
+      - name: Install pytest
         run: |
-          bash scripts/healthcheck.sh
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+      - name: Run healthcheck
+        run: bash scripts/healthcheck.sh

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+pytest -q || exit 1
+# 図のエクスポートは任意（Mermaid未導入でもfailにしない）
+./scripts/export_diagrams.sh || true


### PR DESCRIPTION
## What
- Add minimal healthcheck script and CI workflow

## DoD
- CI runs pytest on PR & main
- Diagrams export is optional and non-blocking