### PR TITLE
feat: add 5 roles skeleton (watcher, curator, planner, synthesizer, archivist)

### DIFF
--- a/playground.py
+++ b/playground.py
@@ -1,0 +1,19 @@
+from src.roles.watcher import Watcher
+from src.roles.curator import Curator
+from src.roles.planner import Planner
+from src.roles.synthesizer import Synthesizer
+from src.roles.archivist import Archivist
+
+
+def run_once(input_text: str):
+    payload = {"input": input_text}
+    for role_cls in [Watcher, Curator, Planner, Synthesizer, Archivist]:
+        role = role_cls()
+        payload = role.run(payload)
+
+
+if __name__ == "__main__":
+    import sys
+
+    input_text = sys.argv[1] if len(sys.argv) > 1 else "hello"
+    run_once(input_text)

--- a/src/roles/archivist.py
+++ b/src/roles/archivist.py
@@ -1,0 +1,4 @@
+class Archivist:
+    def run(self, payload: dict) -> dict:
+        print("[Archivist] received:", payload)
+        return {"role": "Archivist", "output": "dummy output from Archivist"}

--- a/src/roles/curator.py
+++ b/src/roles/curator.py
@@ -1,0 +1,4 @@
+class Curator:
+    def run(self, payload: dict) -> dict:
+        print("[Curator] received:", payload)
+        return {"role": "Curator", "output": "dummy output from Curator"}

--- a/src/roles/planner.py
+++ b/src/roles/planner.py
@@ -1,0 +1,4 @@
+class Planner:
+    def run(self, payload: dict) -> dict:
+        print("[Planner] received:", payload)
+        return {"role": "Planner", "output": "dummy output from Planner"}

--- a/src/roles/synthesizer.py
+++ b/src/roles/synthesizer.py
@@ -1,0 +1,4 @@
+class Synthesizer:
+    def run(self, payload: dict) -> dict:
+        print("[Synthesizer] received:", payload)
+        return {"role": "Synthesizer", "output": "dummy output from Synthesizer"}

--- a/src/roles/watcher.py
+++ b/src/roles/watcher.py
@@ -1,0 +1,4 @@
+class Watcher:
+    def run(self, payload: dict) -> dict:
+        print("[Watcher] received:", payload)
+        return {"role": "Watcher", "output": "dummy output from Watcher"}


### PR DESCRIPTION
## What
- Add minimal skeleton for 5 roles in src/roles/
- Each role has a run() method that receives and returns a payload dict
- Add playground.py to test the 5-role cycle

## DoD
- ✅ `python playground.py 'hello'` shows 5 lines of role execution logs
- ✅ Each role passes payload to the next role
- ✅ CI green with auto-merge