### PR TITLE
feat: phase2-3-pass – add hello Knative Service manifest

### DIFF
--- a/infra/k8s/overlays/dev/hello-ksvc.yaml
+++ b/infra/k8s/overlays/dev/hello-ksvc.yaml
@@ -1,0 +1,17 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: hello
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "0"
+        autoscaling.knative.dev/maxScale: "30"
+    spec:
+      containers:
+        - image: gcr.io/knative-samples/helloworld-go
+          env:
+            - name: TARGET
+              value: "vpm-mini"


### PR DESCRIPTION
## 目的
- Add Hello Knative Service manifest for future verification

## 変更点
- infra/k8s/overlays/dev/hello-ksvc.yaml

## DoD
- [x] CI green
- [ ] Auto-merge 設定済み
- [ ] MERGED 確認済み
- [ ] Snapshot 生成（reports/snap_phase2-3-pass.md）
- [ ] Tag 付与（phase2-3-pass）

## 証跡
- CI: Will be added
- 補足: Minimal Hello KService for testing Knative deployments