### PR TITLE
feat: phase2-5-pass – add Prometheus & Grafana (dev) manifests

### DIFF
--- a/infra/k8s/overlays/dev/monitoring/grafana.yaml
+++ b/infra/k8s/overlays/dev/monitoring/grafana.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  namespace: monitoring
+  labels: { grafana_datasource: "1" }
+data:
+  prometheus.yaml: |
+    apiVersion: 1
+    datasources:
+    - name: Prometheus
+      type: prometheus
+      access: proxy
+      url: http://prometheus.monitoring.svc.cluster.local:9090
+      isDefault: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: grafana } }
+  template:
+    metadata:
+      labels: { app: grafana }
+    spec:
+      containers:
+      - name: grafana
+        image: grafana/grafana:11.1.0
+        ports: [{ containerPort: 3000, name: http }]
+        env:
+        - name: GF_AUTH_ANONYMOUS_ENABLED
+          value: "true"
+        - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+          value: "Viewer"
+        - name: GF_INSTALL_PLUGINS
+          value: ""
+        volumeMounts:
+        - name: datasources
+          mountPath: /etc/grafana/provisioning/datasources
+      volumes:
+      - name: datasources
+        configMap: { name: grafana-datasources }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  selector: { app: grafana }
+  ports:
+  - name: http
+    port: 3000
+    targetPort: 3000

--- a/infra/k8s/overlays/dev/monitoring/namespace.yaml
+++ b/infra/k8s/overlays/dev/monitoring/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring

--- a/infra/k8s/overlays/dev/monitoring/prometheus.yaml
+++ b/infra/k8s/overlays/dev/monitoring/prometheus.yaml
@@ -1,0 +1,116 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-k8s-read
+rules:
+- apiGroups: [""]
+  resources: ["nodes","nodes/proxy","services","endpoints","pods","ingresses","namespaces"]
+  verbs: ["get","list","watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-k8s-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-k8s-read
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: monitoring
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      scrape_timeout: 10s
+    scrape_configs:
+      # Kubernetes service discovery (pods/services/endpoints)
+      - job_name: 'kubernetes-pods'
+        kubernetes_sd_configs:
+        - role: pod
+        relabel_configs:
+        - action: keep
+          source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          regex: "true"
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+          action: replace
+          target_label: __metrics_path__
+          regex: (.+)
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          target_label: __address__
+          regex: (.+)
+          replacement: $1
+      - job_name: 'kubernetes-services'
+        kubernetes_sd_configs:
+        - role: service
+      - job_name: 'kubernetes-nodes'
+        kubernetes_sd_configs:
+        - role: node
+        scheme: https
+        tls_config:
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: prometheus } }
+  template:
+    metadata:
+      labels: { app: prometheus }
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+    spec:
+      serviceAccountName: prometheus
+      containers:
+      - name: prometheus
+        image: prom/prometheus:v2.54.0
+        args:
+          - "--config.file=/etc/prometheus/prometheus.yml"
+          - "--storage.tsdb.path=/prometheus"
+        ports: [{ containerPort: 9090, name: http }]
+        volumeMounts:
+          - name: config
+            mountPath: /etc/prometheus
+          - name: data
+            mountPath: /prometheus
+      volumes:
+        - name: config
+          configMap: { name: prometheus-config }
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  type: ClusterIP
+  selector: { app: prometheus }
+  ports:
+  - name: http
+    port: 9090
+    targetPort: 9090


### PR DESCRIPTION
### Summary
- Add `monitoring` namespace for Prometheus & Grafana
- Add Prometheus with Kubernetes service discovery & RBAC
- Add Grafana with Prometheus datasource (anonymous access)

### DoD
- [x] Namespace: `monitoring`
- [x] Prometheus: service discovery (pods/services/nodes)
- [x] Grafana: anonymous viewer access + Prometheus datasource
- [x] All manifests: `kubectl apply --dry-run=client` passes

### Verification Suite

#### PR Verification
- [ ] CI green (all checks pass)
- [ ] Auto-merge successful
- [ ] No merge conflicts

#### Snapshot Verification
- [ ] Tag created: `phase2-5-pass`
- [ ] Snapshot report generated in `reports/`
- [ ] Git hash matches deployment

#### Manual Verification (Optional)
- [ ] `kubectl apply -f infra/k8s/overlays/dev/monitoring/` succeeds
- [ ] Prometheus pod reaches Ready state
- [ ] Grafana pod reaches Ready state
- [ ] Service endpoints accessible

🤖 Generated with [Claude Code](https://claude.ai/code)