### PR TITLE
feat: phase2-6-pass – autoscale config (min=0,max=30) + load test scripts

### DIFF
--- a/infra/k8s/overlays/dev/hello-ksvc.yaml
+++ b/infra/k8s/overlays/dev/hello-ksvc.yaml
@@ -9,6 +9,7 @@ spec:
       annotations:
         autoscaling.knative.dev/minScale: "0"
         autoscaling.knative.dev/maxScale: "30"
+        autoscaling.knative.dev/target: "100"    # 目標同時リクエスト（デフォルト相当、調整可）
     spec:
       containers:
         - image: gcr.io/knative-samples/helloworld-go

--- a/reports/templates/phase2_autoscale_report.md.tmpl
+++ b/reports/templates/phase2_autoscale_report.md.tmpl
@@ -1,0 +1,16 @@
+# Phase 2 - Autoscale Report (min=0, max=30)
+
+- Timestamp: {{ts}}
+- URL: {{url}}
+- Duration: {{duration}}
+- Concurrency: {{concurrency}}
+
+## Results
+- p50 latency: {{p50}}
+- Requests/sec: {{rps}}
+- Non-2xx errors: {{errors}}
+- Observed replicas max: {{max_replicas}}
+
+## Notes
+- Scale-to-zero: {{stz}}
+- Observations: {{observations}}

--- a/scripts/load_test_hello.sh
+++ b/scripts/load_test_hello.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DURATION="${DURATION:-30s}"
+CONCURRENCY="${CONCURRENCY:-50}"
+URL="${URL:-$(kubectl get ksvc hello -o jsonpath='{.status.url}' 2>/dev/null || true)}"
+
+if ! command -v hey >/dev/null 2>&1; then
+  echo "⚠️ hey が見つかりません。Goがあれば: go install github.com/rakyll/hey@latest"
+  echo "   無い場合は 'ab' (apachebench) を利用します。"; AB_FALLBACK=1
+fi
+
+START=$(date +%s)
+if [ -z "${URL:-}" ]; then
+  echo "✗ URL が取得できません。hello を Ready にしてから実行してください。"
+  exit 1
+fi
+echo "Target: $URL  duration: $DURATION  concurrency: $CONCURRENCY"
+
+TMP=$(mktemp)
+if [ -z "${AB_FALLBACK:-}" ]; then
+  hey -z "$DURATION" -c "$CONCURRENCY" "$URL" | tee "$TMP"
+  P50=$(grep -E '^ 50%' -A0 "$TMP" | awk '{print $2}')
+  ERR=$(grep -E '^Non-2xx' -A0 "$TMP" | awk '{print $3+0}' || echo 0)
+else
+  # ab fallback: だいたい同等のRPS把握のみ
+  SECS=${DURATION%s}
+  ab -k -n $((CONCURRENCY*SECS)) -c "$CONCURRENCY" "$URL/" | tee "$TMP"
+  P50="(ab-no-p50)"
+  ERR=$(grep 'Non-2xx responses' "$TMP" | awk '{print $3+0}' || echo 0)
+fi
+
+END=$(date +%s)
+ELAPSED=$((END-START))
+RPS=$(grep -E 'Requests/sec' "$TMP" | awk '{print $3+0}')
+echo "RESULT p50=${P50}  errors=${ERR}  rps=${RPS}  elapsed=${ELAPSED}s"


### PR DESCRIPTION
## 目的
- Hello KService に autoscale アノテーション（min=0, max=30）を明示し、簡易負荷テストツールとレポート雛形を追加

## 変更点
- 更新: infra/k8s/overlays/dev/hello-ksvc.yaml（autoscale アノテーションを明示）
- 追加: scripts/load_test_hello.sh（hey/ab などで負荷→簡易集計）
- 追加: reports/templates/phase2_autoscale_report.md.tmpl（結果貼り込み用テンプレ）

## DoD
- [ ] CI green
- [ ] Auto-merge 設定済み
- [ ] MERGED 確認済み
- [ ] Snapshot 生成（reports/snap_phase2-6-pass.md）
- [ ] Tag 付与（phase2-6-pass）

## 証跡
- CI: (pending)
- 補足: Autoscale configuration with load testing framework