### PR TITLE
feat: phase2-7-pass – autoscale maxScale=50 + report template

### DIFF
--- a/infra/k8s/overlays/dev/hello-ksvc.yaml
+++ b/infra/k8s/overlays/dev/hello-ksvc.yaml
@@ -8,8 +8,8 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/minScale: "0"
-        autoscaling.knative.dev/maxScale: "30"
-        autoscaling.knative.dev/target: "100"    # 目標同時リクエスト（デフォルト相当、調整可）
+        autoscaling.knative.dev/maxScale: "50"
+        autoscaling.knative.dev/target: "100"
     spec:
       containers:
         - image: gcr.io/knative-samples/helloworld-go

--- a/reports/templates/phase2_autoscale_report_max50.md.tmpl
+++ b/reports/templates/phase2_autoscale_report_max50.md.tmpl
@@ -1,0 +1,16 @@
+# Phase 2 - Autoscale Report (maxScale=50)
+
+- Timestamp: {{ts}}
+- URL: {{url}}
+- Duration: {{duration}}
+- Concurrency: {{concurrency}}
+
+## Results
+- p50 latency: {{p50}}
+- Requests/sec: {{rps}}
+- Non-2xx errors: {{errors}}   <!-- 目標 < 1% -->
+- Observed replicas max: {{max_replicas}}  <!-- 目標: > 1 -->
+
+## Notes
+- Scale-to-zero: {{stz}}
+- Observations: {{observations}}


### PR DESCRIPTION
## 目的
- hello-ksvc を minScale=0 / maxScale=50 に拡張し、負荷試験で p50 < 1s / Non-2xx < 1% を目標に計測

## 変更点
- 更新: infra/k8s/overlays/dev/hello-ksvc.yaml（maxScale: "50" に変更）
- 追加: reports/templates/phase2_autoscale_report_max50.md.tmpl（結果貼り込み用）

## DoD
- [ ] CI green
- [ ] Auto-merge 設定済み
- [ ] MERGED 確認済み
- [ ] Snapshot 生成（reports/snap_phase2-7-pass.md）
- [ ] Tag 付与（phase2-7-pass）

## 証跡
- CI: (pending)
- 補足: Enhanced autoscale configuration for higher load capacity