### PR TITLE
feat: phase2-8-pass – grafana dashboards (dev overview) + port-forward helper

### DIFF
--- a/infra/k8s/overlays/dev/monitoring/grafana-dashboards.yaml
+++ b/infra/k8s/overlays/dev/monitoring/grafana-dashboards.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  vpm-mini-dev-overview.json: |
+    {
+      "id": null,
+      "title": "VPM Mini / Dev Overview",
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "10s",
+      "panels": [
+        {
+          "type": "stat",
+          "title": "up (targets alive)",
+          "gridPos": {"x":0,"y":0,"w":8,"h":6},
+          "targets": [
+            { "expr": "sum(up)", "legendFormat": "alive" }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Requests/sec (all jobs)",
+          "gridPos": {"x":8,"y":0,"w":16,"h":6},
+          "targets": [
+            { "expr": "rate(prometheus_tsdb_head_series{job=\"prometheus\"}[1m])", "legendFormat": "prom series rate" }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Node CPU (kind node, sample)",
+          "gridPos": {"x":0,"y":6,"w":12,"h":7},
+          "targets": [
+            { "expr": "sum(rate(container_cpu_usage_seconds_total{image!=\"\",container!=\"POD\"}[2m]))", "legendFormat": "cpu total" }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Node Memory (working set)",
+          "gridPos": {"x":12,"y":6,"w":12,"h":7},
+          "targets": [
+            { "expr": "sum(container_memory_working_set_bytes{image!=\"\",container!=\"POD\"})", "legendFormat": "mem working set" }
+          ]
+        }
+      ],
+      "templating": { "list": [] }
+    }
+---
+# Grafana が自動で dashboards/ を読むように、既存 Deployment へ volume をマウント（既存と併用想定）
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      volumes:
+      - name: dashboards
+        configMap:
+          name: grafana-dashboards
+      containers:
+      - name: grafana
+        volumeMounts:
+        - name: dashboards
+          mountPath: /var/lib/grafana/dashboards
+        env:
+        - name: GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH
+          value: /var/lib/grafana/dashboards/vpm-mini-dev-overview.json
+        - name: GF_DASHBOARDS_ENABLE
+          value: "true"

--- a/reports/templates/phase2_dashboard_notes.md.tmpl
+++ b/reports/templates/phase2_dashboard_notes.md.tmpl
@@ -1,0 +1,12 @@
+# Phase 2 - Dashboard Notes
+
+- Timestamp: {{ts}}
+- Access: http://localhost:3000  (port-forward: `bash scripts/port_forward_grafana.sh`)
+- Panels:
+  - up (targets)
+  - Requests/sec (prom series)
+  - Node CPU/Memory (working set)
+
+## Next Ideas
+- Kourier/Knative コンポーネントのメトリクスを追加入力
+- hello ksvc 呼応の RPS / p50 を可視化（次ステップのExporter/面で対応）

--- a/scripts/port_forward_grafana.sh
+++ b/scripts/port_forward_grafana.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+NAMESPACE="${NAMESPACE:-monitoring}"
+PORT="${PORT:-3000}"
+echo "Port-forward Grafana on http://localhost:${PORT}"
+kubectl -n "$NAMESPACE" port-forward svc/grafana "${PORT}:3000"


### PR DESCRIPTION
## 目的
- dev最小構成で Grafana に 初期ダッシュボード（稼働状況の"見える化"の骨組み）と アクセス導線 を追加

## 変更点
- 追加: infra/k8s/overlays/dev/monitoring/grafana-dashboards.yaml（ダッシュボードJSONのConfigMap + 自動読込）
- 追加: scripts/port_forward_grafana.sh（アクセス導線）
- 追加: reports/templates/phase2_dashboard_notes.md.tmpl（メモ雛形）

## DoD
- [ ] CI green
- [ ] Auto-merge 設定済み
- [ ] MERGED 確認済み
- [ ] Snapshot 生成（reports/snap_phase2-8-pass.md）
- [ ] Tag 付与（phase2-8-pass）

## 証跡
- CI: (pending)
- 補足: Grafana dashboard and monitoring visualization foundation