### PR TITLE
chore: Phase 2 exit checklist & verifier

### DIFF
--- a/reports/templates/phase2_exit_checklist.md.tmpl
+++ b/reports/templates/phase2_exit_checklist.md.tmpl
@@ -1,0 +1,21 @@
+# Phase 2 Exit Checklist
+
+## Summary
+- Date: {{ts}}
+- Commit: {{commit}}
+- Branch: {{branch}}
+
+## Exit Criteria
+- [{{hello_ready}}] Hello KService READY=True
+- [{{autoscale_ok}}] Autoscale works (min=0 / max=50) and scaled >1 under load
+- [{{monitoring_ok}}] Monitoring stack (Prometheus & Grafana) running
+- [{{perf_ok}}] p50 < 1s / JSON errors < 1% (scope-limited smoke test)
+
+## Evidence
+- Hello URL: {{hello_url}}
+- Max replicas observed: {{max_replicas}}
+- p50: {{p50}}
+- Requests/sec: {{rps}}
+- Non-2xx errors: {{errors}}
+
+Notes: {{notes}}

--- a/scripts/phase2_verify_exit.sh
+++ b/scripts/phase2_verify_exit.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+stamp(){ date +%Y-%m-%dT%H:%M:%S%z; }
+field(){ v="$1"; [ -z "$v" ] && echo "n/a" || echo "$v"; }
+
+TS=$(stamp)
+COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo n/a)
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo n/a)
+
+HELLO_READY=" "
+AUTOSCALE_OK=" "
+MON_OK=" "
+PERF_OK=" "
+
+HELLO_URL=""
+MAXR=""
+P50=""
+RPS=""
+ERRS=""
+NOTES="no live cluster; relying on prior PR artifacts"
+
+if kubectl cluster-info >/dev/null 2>&1; then
+  # Hello Ready
+  if kubectl get ksvc hello >/dev/null 2>&1; then
+    if kubectl get ksvc hello -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep -q True; then
+      HELLO_READY="x"
+      HELLO_URL="$(kubectl get ksvc hello -o jsonpath='{.status.url}')"
+    fi
+  fi
+
+  # Autoscale: 観測ベース（現在のPod数>1ならOK。なければn/a）
+  MAXR=$(kubectl get pods -l serving.knative.dev/service=hello --no-headers 2>/dev/null | wc -l | awk '{print $1}')
+  [ -n "$MAXR" ] && [ "$MAXR" -ge 2 ] && AUTOSCALE_OK="x"
+
+  # Monitoring stack
+  if kubectl -n monitoring get deploy prometheus grafana >/dev/null 2>&1; then
+    POK=$(kubectl -n monitoring get deploy prometheus -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null)
+    GOK=$(kubectl -n monitoring get deploy grafana -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null)
+    if echo "$POK$GOK" | grep -q True; then MON_OK="x"; fi
+  fi
+
+  # Perf（存在すれば hey/ab 直近結果から拾う）— 任意
+  if [ -f /tmp/load_max50.txt ]; then
+    P50=$(grep -E 'p50=| 50%' /tmp/load_max50.txt | head -n1 | sed -E 's/.*p50=([^ ]+).*/\1/;t; s/.* 50%[[:space:]]+([^ ]+).*/\1/')
+    RPS=$(grep -E 'Requests/sec' /tmp/load_max50.txt | awk '{print $3+0}')
+    ERRS=$(grep -E 'Non-2xx|errors=' /tmp/load_max50.txt | head -n1 | sed -E 's/.*errors=([0-9]+).*/\1/;t; s/.*Non-2xx responses: ([0-9]+).*/\1/'; true)
+    [ -z "$ERRS" ] && ERRS=0
+    # ラフ判定
+    if [ -n "$P50" ]; then
+      # p50が 1s 未満か大雑把に判定（ms or s を含むケースの簡易判定）
+      if echo "$P50" | grep -Eq 'ms'; then PERF_OK="x"
+      elif echo "$P50" | grep -Eq '(^0\.[0-9]+s$)|(^[0-1](\.[0-9]+)?s$)'; then PERF_OK="x"
+      fi
+    fi
+    NOTES="live cluster verified"
+  fi
+fi
+
+# テンプレに流し込み
+OUT="reports/phase2_exit_status_$(date +%Y%m%d-%H%M%S).md"
+sed "s/{{ts}}/$TS/; s/{{commit}}/$COMMIT/; s/{{branch}}/$BRANCH/; \
+s/{{hello_ready}}/$HELLO_READY/; s/{{autoscale_ok}}/$AUTOSCALE_OK/; s/{{monitoring_ok}}/$MON_OK/; s/{{perf_ok}}/$PERF_OK/; \
+s#{{hello_url}}#$(field "$HELLO_URL")#; s/{{max_replicas}}/$(field "$MAXR")/; \
+s/{{p50}}/$(field "$P50")/; s/{{rps}}/$(field "$RPS")/; s/{{errors}}/$(field "$ERRS")/; \
+s#{{notes}}#$(echo "$NOTES" | sed 's/[&/]/\\&/g')#" \
+reports/templates/phase2_exit_checklist.md.tmpl > "$OUT"
+
+echo "Wrote $OUT"


### PR DESCRIPTION
## 目的
- Phase 2 の Exit 条件を明文化し、最終スナップショットとタグで SSOT を固定

## 変更点
- 追加: reports/templates/phase2_exit_checklist.md.tmpl（退出チェック雛形）
- 追加: scripts/phase2_verify_exit.sh（任意の実機検証スクリプト）

## Exit 条件（Phase 2）
- Hello KService: READY=True
- Autoscale: min=0 / max=50 動作（簡易負荷でスケール>1 を確認）
- 観測基盤: Prometheus / Grafana 稼働
- 目標品質: p50 < 1s / JSON エラー < 1%（簡易テスト範囲での達成）

## DoD
- [ ] CI green
- [ ] Auto-merge 設定済み
- [ ] MERGED 確認済み
- [ ] Snapshot 生成（reports/snap_phase2-complete.md）
- [ ] Tag 付与（phase2-complete）

## 証跡
- CI: (pending)
- 補足: Phase 2 completion with documented exit criteria