### PR TITLE
feat(p3-1): add SPIRE server/agent & k8s-workload-registrar

### DIFF
--- a/infra/k8s/base/spire/agent-configmap.yaml
+++ b/infra/k8s/base/spire/agent-configmap.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spire-agent
+  namespace: spire-system
+data:
+  agent.conf: |
+    agent {
+      data_dir = "/run/spire"
+      log_level = "DEBUG"
+      trust_domain = "vpm-mini.local"
+      server_address = "spire-server"
+      server_port = "8081"
+      socket_path = "/run/spire/sockets/agent.sock"
+    }
+
+    plugins {
+      NodeAttestor "k8s_psat" {
+        plugin_data {
+          cluster = "kind"
+          token_path = "/run/secrets/tokens/spire-agent"
+        }
+      }
+
+      KeyManager "memory" {
+        plugin_data {}
+      }
+
+      WorkloadAttestor "k8s" {
+        plugin_data {
+          skip_kubelet_verification = true
+        }
+      }
+
+      WorkloadAttestor "unix" {
+        plugin_data {}
+      }
+    }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }

--- a/infra/k8s/base/spire/agent-daemonset.yaml
+++ b/infra/k8s/base/spire/agent-daemonset.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: spire-agent
+  namespace: spire-system
+spec:
+  selector:
+    matchLabels:
+      app: spire-agent
+  template:
+    metadata:
+      labels:
+        app: spire-agent
+    spec:
+      hostNetwork: true
+      hostPID: true
+      serviceAccountName: spire-agent
+      containers:
+      - name: spire-agent
+        image: ghcr.io/spiffe/spire-agent:1.8.0
+        args:
+        - -config
+        - /run/spire/config/agent.conf
+        ports:
+        - containerPort: 8080
+          name: healthz
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: 8080
+          failureThreshold: 2
+          initialDelaySeconds: 15
+          periodSeconds: 60
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+        - name: config
+          mountPath: /run/spire/config
+          readOnly: true
+        - name: spire-token
+          mountPath: /run/secrets/tokens
+        - name: spire-agent-socket
+          mountPath: /run/spire/sockets
+      initContainers:
+      - name: init
+        image: busybox:1.36
+        command:
+        - /bin/sh
+        - -c
+        - |
+          mkdir -p /run/spire/sockets
+          chmod 755 /run/spire/sockets
+        volumeMounts:
+        - name: spire-agent-socket
+          mountPath: /run/spire/sockets
+      volumes:
+      - name: config
+        configMap:
+          name: spire-agent
+      - name: spire-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: spire-server
+              expirationSeconds: 7200
+              path: spire-agent
+      - name: spire-agent-socket
+        hostPath:
+          path: /run/spire/sockets
+          type: DirectoryOrCreate

--- a/infra/k8s/base/spire/bundle-configmap.yaml
+++ b/infra/k8s/base/spire/bundle-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spire-bundle
+  namespace: spire-system
+data:
+  bundle.crt: ""

--- a/infra/k8s/base/spire/namespace.yaml
+++ b/infra/k8s/base/spire/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spire-system
+  labels:
+    name: spire-system
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/audit: privileged

--- a/infra/k8s/base/spire/rbac.yaml
+++ b/infra/k8s/base/spire/rbac.yaml
@@ -1,0 +1,102 @@
+---
+# ServiceAccount for SPIRE Server
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spire-server
+  namespace: spire-system
+---
+# ServiceAccount for SPIRE Agent
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spire-agent
+  namespace: spire-system
+---
+# ServiceAccount for Workload Registrar
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spire-workload-registrar
+  namespace: spire-system
+---
+# RBAC for SPIRE Server - ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: spire-server-trust-role
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list"]
+---
+# RBAC for SPIRE Server - ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: spire-server-trust-role-binding
+roleRef:
+  kind: ClusterRole
+  name: spire-server-trust-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: spire-server
+  namespace: spire-system
+---
+# RBAC for SPIRE Agent - ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: spire-agent-trust-role
+rules:
+- apiGroups: [""]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list"]
+---
+# RBAC for SPIRE Agent - ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: spire-agent-trust-role-binding
+roleRef:
+  kind: ClusterRole
+  name: spire-agent-trust-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: spire-agent
+  namespace: spire-system
+---
+# RBAC for Workload Registrar - ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: spire-workload-registrar-role
+rules:
+- apiGroups: [""]
+  resources: ["pods", "serviceaccounts", "namespaces", "nodes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
+---
+# RBAC for Workload Registrar - ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: spire-workload-registrar-role-binding
+roleRef:
+  kind: ClusterRole
+  name: spire-workload-registrar-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: spire-workload-registrar
+  namespace: spire-system

--- a/infra/k8s/base/spire/server-configmap.yaml
+++ b/infra/k8s/base/spire/server-configmap.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spire-server
+  namespace: spire-system
+data:
+  server.conf: |
+    server {
+      bind_address = "0.0.0.0"
+      bind_port = "8081"
+      trust_domain = "vpm-mini.local"
+      data_dir = "/run/spire/data"
+      log_level = "DEBUG"
+      socket_path = "/run/spire/sockets/server.sock"
+    }
+
+    plugins {
+      DataStore "sql" {
+        plugin_data {
+          database_type = "sqlite3"
+          connection_string = "/run/spire/data/datastore.sqlite3"
+        }
+      }
+
+      NodeAttestor "k8s_psat" {
+        plugin_data {
+          clusters = {
+            "kind" = {
+              service_account_allow_list = ["spire-system:spire-agent"]
+            }
+          }
+        }
+      }
+
+      KeyManager "memory" {
+        plugin_data {}
+      }
+
+      UpstreamAuthority "disk" {
+        plugin_data {
+          key_file_path = "/run/spire/data/upstream.key"
+          cert_file_path = "/run/spire/data/upstream.crt"
+        }
+      }
+
+      Notifier "k8sbundle" {
+        plugin_data {
+          config_map = "spire-bundle"
+          namespace = "spire-system"
+        }
+      }
+    }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }

--- a/infra/k8s/base/spire/server-service.yaml
+++ b/infra/k8s/base/spire/server-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: spire-server
+  namespace: spire-system
+spec:
+  type: ClusterIP
+  selector:
+    app: spire-server
+  ports:
+  - name: grpc
+    port: 8081
+    targetPort: 8081
+    protocol: TCP

--- a/infra/k8s/base/spire/server-statefulset.yaml
+++ b/infra/k8s/base/spire/server-statefulset.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: spire-server
+  namespace: spire-system
+spec:
+  replicas: 1
+  serviceName: spire-server
+  selector:
+    matchLabels:
+      app: spire-server
+  template:
+    metadata:
+      labels:
+        app: spire-server
+    spec:
+      serviceAccountName: spire-server
+      containers:
+      - name: spire-server
+        image: ghcr.io/spiffe/spire-server:1.8.0
+        args:
+        - -config
+        - /run/spire/config/server.conf
+        ports:
+        - containerPort: 8081
+          name: grpc
+        - containerPort: 8080
+          name: healthz
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: 8080
+          failureThreshold: 2
+          initialDelaySeconds: 15
+          periodSeconds: 60
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+        - name: config
+          mountPath: /run/spire/config
+          readOnly: true
+        - name: data
+          mountPath: /run/spire/data
+      volumes:
+      - name: config
+        configMap:
+          name: spire-server
+      - name: data
+        emptyDir: {}

--- a/infra/k8s/base/spire/workload-registrar-configmap.yaml
+++ b/infra/k8s/base/spire/workload-registrar-configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-workload-registrar
+  namespace: spire-system
+data:
+  registrar.conf: |
+    trust_domain = "vpm-mini.local"
+    server_address = "spire-server:8081"
+    cluster = "kind"
+    mode = "reconcile"
+    pod_annotation = "spiffe.io/inject"
+    disabled_namespaces = ["kube-system", "kube-public"]

--- a/infra/k8s/base/spire/workload-registrar-deployment.yaml
+++ b/infra/k8s/base/spire/workload-registrar-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spire-k8s-workload-registrar
+  namespace: spire-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spire-k8s-workload-registrar
+  template:
+    metadata:
+      labels:
+        app: spire-k8s-workload-registrar
+    spec:
+      serviceAccountName: spire-workload-registrar
+      containers:
+      - name: k8s-workload-registrar
+        image: ghcr.io/spiffe/k8s-workload-registrar:1.8.0
+        args:
+        - -config
+        - /run/spire/config/registrar.conf
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: config
+          mountPath: /run/spire/config
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: k8s-workload-registrar

--- a/infra/k8s/overlays/dev/examples/namespace.yaml
+++ b/infra/k8s/overlays/dev/examples/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hyper-swarm
+  labels:
+    name: hyper-swarm

--- a/infra/k8s/overlays/dev/examples/planner-test-pod.yaml
+++ b/infra/k8s/overlays/dev/examples/planner-test-pod.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: planner-debug
+  namespace: hyper-swarm
+  annotations:
+    spiffe.io/inject: "true"
+spec:
+  serviceAccountName: planner-sa
+  containers:
+  - name: debug
+    image: alpine:3.19
+    command:
+    - /bin/sh
+    - -c
+    - |
+      echo "SPIRE Test Pod Started"
+      while true; do
+        sleep 30
+        echo "Checking SPIRE socket..."
+        ls -la /run/spire/sockets/agent.sock 2>/dev/null || echo "Socket not found"
+      done
+    volumeMounts:
+    - name: spire-agent-socket
+      mountPath: /run/spire/sockets
+      readOnly: true
+  volumes:
+  - name: spire-agent-socket
+    hostPath:
+      path: /run/spire/sockets
+      type: DirectoryOrCreate

--- a/infra/k8s/overlays/dev/examples/planner-test-sa.yaml
+++ b/infra/k8s/overlays/dev/examples/planner-test-sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: planner-sa
+  namespace: hyper-swarm
+  annotations:
+    spiffe.io/inject: "true"

--- a/reports/templates/phase3_spire_verify.md.tmpl
+++ b/reports/templates/phase3_spire_verify.md.tmpl
@@ -1,0 +1,26 @@
+# SPIRE Verification Report
+
+**Date:** {{timestamp}}  
+**Cluster:** {{cluster_name}}  
+**Trust Domain:** {{trust_domain}}
+
+## Component Status
+- **SPIRE Server:** {{server_status}}
+- **SPIRE Agent:** {{agent_status}}
+- **Workload Registrar:** {{registrar_status}}
+
+## Workload Identity
+- **Test ServiceAccount:** {{test_sa}}
+- **SPIFFE ID:** {{spiffe_id}}
+- **Socket Mount:** {{socket_status}}
+
+## Verification Details
+```
+{{verification_details}}
+```
+
+## Next Steps
+{{next_steps}}
+
+## Notes
+{{notes}}

--- a/scripts/phase3_spire_bootstrap.sh
+++ b/scripts/phase3_spire_bootstrap.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== SPIRE Bootstrap Script ==="
+echo "Deploying SPIRE components to Kubernetes cluster..."
+
+# Check cluster connectivity
+if ! kubectl cluster-info >/dev/null 2>&1; then
+    echo "❌ Cannot connect to Kubernetes cluster"
+    exit 1
+fi
+
+echo "✅ Connected to cluster"
+
+# Apply SPIRE base manifests
+echo ""
+echo "📦 Applying SPIRE base manifests..."
+kubectl apply -f infra/k8s/base/spire/namespace.yaml
+kubectl apply -f infra/k8s/base/spire/rbac.yaml
+kubectl apply -f infra/k8s/base/spire/bundle-configmap.yaml
+kubectl apply -f infra/k8s/base/spire/server-configmap.yaml
+kubectl apply -f infra/k8s/base/spire/server-statefulset.yaml
+kubectl apply -f infra/k8s/base/spire/server-service.yaml
+kubectl apply -f infra/k8s/base/spire/agent-configmap.yaml
+kubectl apply -f infra/k8s/base/spire/agent-daemonset.yaml
+kubectl apply -f infra/k8s/base/spire/workload-registrar-configmap.yaml
+kubectl apply -f infra/k8s/base/spire/workload-registrar-deployment.yaml
+
+echo ""
+echo "⏳ Waiting for SPIRE Server to be ready..."
+kubectl -n spire-system rollout status statefulset/spire-server --timeout=180s
+
+echo ""
+echo "⏳ Waiting for SPIRE Agent to be ready..."
+kubectl -n spire-system rollout status daemonset/spire-agent --timeout=180s
+
+echo ""
+echo "⏳ Waiting for Workload Registrar to be ready..."
+kubectl -n spire-system rollout status deployment/spire-k8s-workload-registrar --timeout=180s
+
+echo ""
+echo "📦 Applying test workloads..."
+kubectl apply -f infra/k8s/overlays/dev/examples/namespace.yaml
+kubectl apply -f infra/k8s/overlays/dev/examples/planner-test-sa.yaml
+kubectl apply -f infra/k8s/overlays/dev/examples/planner-test-pod.yaml
+
+echo ""
+echo "⏳ Waiting for test pod to be ready..."
+kubectl -n hyper-swarm wait pod/planner-debug --for=condition=ready --timeout=60s || true
+
+echo ""
+echo "✅ SPIRE bootstrap complete!"
+echo ""
+echo "📊 SPIRE System Status:"
+kubectl -n spire-system get pods -o wide
+
+echo ""
+echo "🧪 Test Workload Status:"
+kubectl -n hyper-swarm get pods -o wide
+
+echo ""
+echo "Run 'bash scripts/phase3_spire_verify.sh' to verify SPIRE setup"

--- a/scripts/phase3_spire_verify.sh
+++ b/scripts/phase3_spire_verify.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== SPIRE Verification Script ==="
+echo ""
+
+# Initialize result tracking
+RESULT_OK=true
+RESULT_DETAILS=""
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Function to add result detail
+add_result() {
+    local check="$1"
+    local status="$2"
+    local detail="$3"
+    RESULT_DETAILS="${RESULT_DETAILS}  - ${check}: ${status} (${detail})\n"
+    if [ "$status" != "OK" ]; then
+        RESULT_OK=false
+    fi
+}
+
+# Check 1: SPIRE Server health
+echo "🔍 Checking SPIRE Server health..."
+if kubectl -n spire-system get statefulset spire-server -o jsonpath='{.status.readyReplicas}' | grep -q '1'; then
+    SERVER_LOG=$(kubectl -n spire-system logs statefulset/spire-server --tail=5 2>&1 | grep -E "(INFO|DEBUG)" | tail -1 || echo "No logs")
+    echo "✅ SPIRE Server is running"
+    add_result "spire-server" "OK" "Ready 1/1"
+else
+    echo "❌ SPIRE Server is not ready"
+    add_result "spire-server" "FAIL" "Not ready"
+fi
+
+# Check 2: SPIRE Agent health
+echo ""
+echo "🔍 Checking SPIRE Agent health..."
+AGENT_DESIRED=$(kubectl -n spire-system get daemonset spire-agent -o jsonpath='{.status.desiredNumberScheduled}')
+AGENT_READY=$(kubectl -n spire-system get daemonset spire-agent -o jsonpath='{.status.numberReady}')
+if [ "$AGENT_DESIRED" = "$AGENT_READY" ] && [ "$AGENT_READY" -gt 0 ]; then
+    echo "✅ SPIRE Agent DaemonSet is running ($AGENT_READY/$AGENT_DESIRED)"
+    add_result "spire-agent" "OK" "Ready $AGENT_READY/$AGENT_DESIRED"
+else
+    echo "❌ SPIRE Agent DaemonSet is not ready ($AGENT_READY/$AGENT_DESIRED)"
+    add_result "spire-agent" "FAIL" "Not ready $AGENT_READY/$AGENT_DESIRED"
+fi
+
+# Check 3: Workload Registrar health
+echo ""
+echo "🔍 Checking Workload Registrar health..."
+if kubectl -n spire-system get deployment spire-k8s-workload-registrar -o jsonpath='{.status.readyReplicas}' | grep -q '1'; then
+    echo "✅ Workload Registrar is running"
+    add_result "workload-registrar" "OK" "Ready 1/1"
+else
+    echo "❌ Workload Registrar is not ready"
+    add_result "workload-registrar" "FAIL" "Not ready"
+fi
+
+# Check 4: Workload entries
+echo ""
+echo "🔍 Checking registered workload entries..."
+echo ""
+# Create entry show command
+ENTRY_CMD="/opt/spire/bin/spire-server entry show"
+ENTRIES=$(kubectl -n spire-system exec statefulset/spire-server -- $ENTRY_CMD 2>/dev/null || echo "")
+echo "$ENTRIES" > reports/spire_entries.txt
+
+# Check for planner-sa entry
+if echo "$ENTRIES" | grep -q "spiffe://vpm-mini.local/ns/hyper-swarm/sa/planner-sa"; then
+    echo "✅ Found SPIFFE ID for planner-sa"
+    add_result "workload-entry-planner" "OK" "spiffe://vpm-mini.local/ns/hyper-swarm/sa/planner-sa"
+    
+    # Display the entry details
+    echo ""
+    echo "📋 Planner SA Entry Details:"
+    echo "$ENTRIES" | grep -A 5 "spiffe://vpm-mini.local/ns/hyper-swarm/sa/planner-sa" | head -10
+else
+    echo "❌ No SPIFFE ID found for planner-sa"
+    add_result "workload-entry-planner" "FAIL" "No entry found"
+fi
+
+# Check 5: Socket mount in test pod
+echo ""
+echo "🔍 Checking SPIRE socket mount in test pod..."
+SOCKET_CHECK=$(kubectl -n hyper-swarm exec pod/planner-debug -- ls -la /run/spire/sockets/ 2>/dev/null || echo "Socket directory not found")
+echo "$SOCKET_CHECK" > reports/spire_socket_check.txt
+
+if echo "$SOCKET_CHECK" | grep -q "agent.sock"; then
+    echo "✅ SPIRE agent socket is mounted in test pod"
+    add_result "socket-mount" "OK" "/run/spire/sockets/agent.sock exists"
+    echo ""
+    echo "📋 Socket Details:"
+    echo "$SOCKET_CHECK"
+else
+    echo "❌ SPIRE agent socket not found in test pod"
+    add_result "socket-mount" "FAIL" "Socket not found"
+fi
+
+# Generate JSON report
+echo ""
+echo "📝 Generating verification report..."
+mkdir -p reports
+
+cat > reports/phase3_spire_verify.json <<EOF
+{
+  "timestamp": "$TIMESTAMP",
+  "status": $([ "$RESULT_OK" = true ] && echo '"OK"' || echo '"FAIL"'),
+  "checks": [
+$(echo -e "$RESULT_DETAILS" | sed 's/^  - /    { "check": "/g; s/: /" , "status": "/g; s/ (/", "detail": "/g; s/)$/"},/g' | sed '$ s/,$//')
+  ],
+  "entries_file": "reports/spire_entries.txt",
+  "socket_check_file": "reports/spire_socket_check.txt"
+}
+EOF
+
+# Also create markdown report
+cat > reports/phase3_spire_verify.md <<EOF
+# SPIRE Verification Report
+
+**Timestamp:** $TIMESTAMP  
+**Overall Status:** $([ "$RESULT_OK" = true ] && echo '✅ PASS' || echo '❌ FAIL')
+
+## Check Results
+
+$(echo -e "$RESULT_DETAILS")
+
+## Files Generated
+- \`reports/spire_entries.txt\` - Full SPIRE entry list
+- \`reports/spire_socket_check.txt\` - Socket mount verification
+- \`reports/phase3_spire_verify.json\` - JSON verification report
+
+## Summary
+$([ "$RESULT_OK" = true ] && echo 'All checks passed. SPIRE is ready for workload identity management.' || echo 'Some checks failed. Please review the details above.')
+EOF
+
+echo ""
+echo "✅ Verification complete!"
+echo ""
+echo "📊 Summary:"
+echo "  - JSON Report: reports/phase3_spire_verify.json"
+echo "  - Markdown Report: reports/phase3_spire_verify.md"
+echo "  - Entry List: reports/spire_entries.txt"
+echo "  - Socket Check: reports/spire_socket_check.txt"
+echo ""
+if [ "$RESULT_OK" = true ]; then
+    echo "🎉 All checks passed! SPIRE is operational."
+else
+    echo "⚠️  Some checks failed. Please review the reports."
+fi


### PR DESCRIPTION
## 目的
すべてのセル（Pod/KService）に SPIFFE ID（例: spiffe://vpm-mini.local/ns/<ns>/sa/<sa>）を付与できる足場を用意する。

## 変更内容
### SPIRE Components
- **Namespace:** spire-system
- **Trust Domain:** vpm-mini.local
- **Server:** StatefulSet with SQLite backend
- **Agent:** DaemonSet with host socket mount at /run/spire/sockets
- **Workload Registrar:** Automatic entry management for annotated workloads

### Test Workloads
- **Namespace:** hyper-swarm
- **ServiceAccount:** planner-sa
- **Test Pod:** planner-debug with socket mount

### Scripts
- `scripts/phase3_spire_bootstrap.sh` - Deploy all SPIRE components
- `scripts/phase3_spire_verify.sh` - Verify SPIRE setup and generate reports

## DoD
- [ ] spire-system に server/agent/registrar が稼働（Ready=1/1）
- [ ] hyper-swarm の planner-sa を用いた Workload エントリが自動生成されている
- [ ] テスト Pod planner-debug 内で SPIRE Agent のソケットがマウントされている
- [ ] reports/phase3_spire_verify.json が Green（OK=true）で保存される
- [ ] CI green
- [ ] タグ phase3-1-spiffe-ready を付与

## テスト手順
```bash
# 1) Bootstrap SPIRE
bash scripts/phase3_spire_bootstrap.sh

# 2) Verify setup
bash scripts/phase3_spire_verify.sh

# 3) Check results
cat reports/phase3_spire_verify.json
```

## ラベル
- phase:3
- area:security
- kind:infra