### PR TITLE
feat(p3-2): add OPA Gatekeeper and baseline constraints

### DIFF
--- a/infra/k8s/base/gatekeeper/system/gatekeeper.yaml
+++ b/infra/k8s/base/gatekeeper/system/gatekeeper.yaml
@@ -1,0 +1,566 @@
+# This is a modified version of the official Gatekeeper release manifest
+# Original: https://raw.githubusercontent.com/open-policy-agent/gatekeeper/release-3.15/deploy/gatekeeper.yaml
+# Modified for vpm-mini with minimal configuration
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    admission.gatekeeper.sh/ignore: no-self-managing
+    control-plane: controller-manager
+    gatekeeper.sh/system: "yes"
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: v1.24
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+  name: gatekeeper-system
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: gatekeeper-critical-pods
+  namespace: gatekeeper-system
+spec:
+  hard:
+    pods: "100"
+  scopeSelector:
+    matchExpressions:
+    - operator: In
+      scopeName: PriorityClass
+      values:
+      - system-cluster-critical
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: configs.config.gatekeeper.sh
+spec:
+  group: config.gatekeeper.sh
+  names:
+    kind: Config
+    listKind: ConfigList
+    plural: configs
+    singular: config
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Config is the Schema for the configs API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object.'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents.'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConfigSpec defines the desired state of Config.
+            properties:
+              match:
+                description: Configuration for namespace exclusion
+                items:
+                  properties:
+                    excludedNamespaces:
+                      items:
+                        type: string
+                      type: array
+                    processes:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              sync:
+                description: Configuration for syncing k8s objects
+                properties:
+                  syncOnly:
+                    description: If non-empty, only entries on this list will be replicated into OPA
+                    items:
+                      properties:
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        version:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              validation:
+                description: Configuration for validation
+                properties:
+                  traces:
+                    description: List of requests to trace
+                    items:
+                      properties:
+                        user:
+                          description: Only trace requests from the specified user
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        kind:
+                          description: Only trace requests of the specified kind
+                          properties:
+                            group:
+                              type: string
+                            kind:
+                              type: string
+                            version:
+                              type: string
+                          type: object
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: ConfigStatus defines the observed state of Config.
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: constrainttemplates.templates.gatekeeper.sh
+spec:
+  group: templates.gatekeeper.sh
+  names:
+    kind: ConstraintTemplate
+    listKind: ConstraintTemplateList
+    plural: constrainttemplates
+    singular: constrainttemplate
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object.'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents.'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              crd:
+                properties:
+                  spec:
+                    properties:
+                      names:
+                        properties:
+                          kind:
+                            type: string
+                          shortNames:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      validation:
+                        default:
+                          properties:
+                            properties:
+                              type: object
+                        type: object
+                    type: object
+                type: object
+              targets:
+                items:
+                  properties:
+                    target:
+                      type: string
+                    rego:
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            properties:
+              created:
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: gatekeeper-admin
+  namespace: gatekeeper-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: gatekeeper-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - "*"
+  resources:
+  - "*"
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingadmissionwebhooks
+  - validatingadmissionwebhooks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - config.gatekeeper.sh
+  resources:
+  - configs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - templates.gatekeeper.sh
+  resources:
+  - constrainttemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - templates.gatekeeper.sh
+  resources:
+  - constrainttemplates/finalizers
+  verbs:
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - templates.gatekeeper.sh
+  resources:
+  - constrainttemplates/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: gatekeeper-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gatekeeper-manager-role
+subjects:
+- kind: ServiceAccount
+  name: gatekeeper-admin
+  namespace: gatekeeper-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: gatekeeper-webhook-service
+  namespace: gatekeeper-system
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+    gatekeeper.sh/operation: webhook
+    gatekeeper.sh/system: "yes"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: audit-controller
+    gatekeeper.sh/operation: audit
+    gatekeeper.sh/system: "yes"
+  name: gatekeeper-audit
+  namespace: gatekeeper-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: audit-controller
+      gatekeeper.sh/operation: audit
+      gatekeeper.sh/system: "yes"
+  template:
+    metadata:
+      annotations:
+        container.seccomp.security.alpha.kubernetes.io/manager: runtime/default
+      labels:
+        control-plane: audit-controller
+        gatekeeper.sh/operation: audit
+        gatekeeper.sh/system: "yes"
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - --operation=audit
+        - --operation=status
+        - --logtostderr
+        - --disable-opa-builtin={http.send}
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: openpolicyagent/gatekeeper:v3.15.0
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9090
+        name: manager
+        ports:
+        - containerPort: 8888
+          name: metrics
+          protocol: TCP
+        - containerPort: 9090
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 9090
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 999
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      serviceAccountName: gatekeeper-admin
+      terminationGracePeriodSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+    gatekeeper.sh/operation: webhook
+    gatekeeper.sh/system: "yes"
+  name: gatekeeper-controller-manager
+  namespace: gatekeeper-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      gatekeeper.sh/operation: webhook
+      gatekeeper.sh/system: "yes"
+  template:
+    metadata:
+      annotations:
+        container.seccomp.security.alpha.kubernetes.io/manager: runtime/default
+      labels:
+        control-plane: controller-manager
+        gatekeeper.sh/operation: webhook
+        gatekeeper.sh/system: "yes"
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - --port=8443
+        - --logtostderr
+        - --exempt-namespace=gatekeeper-system
+        - --operation=webhook
+        - --operation=mutation-webhook
+        - --disable-opa-builtin={http.send}
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: openpolicyagent/gatekeeper:v3.15.0
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9090
+        name: manager
+        ports:
+        - containerPort: 8443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 8888
+          name: metrics
+          protocol: TCP
+        - containerPort: 9090
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 9090
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 999
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /certs
+          name: cert
+          readOnly: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      serviceAccountName: gatekeeper-admin
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: gatekeeper-webhook-server-cert  # pragma: allowlist secret
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionWebhook
+metadata:
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: gatekeeper-validating-admission-webhook
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: gatekeeper-webhook-service
+      namespace: gatekeeper-system
+      path: /v1/admit
+  failurePolicy: Ignore
+  matchPolicy: Exact
+  name: validation.gatekeeper.sh
+  namespaceSelector:
+    matchExpressions:
+    - key: admission.gatekeeper.sh/ignore
+      operator: DoesNotExist
+  rules:
+  - apiGroups:
+    - '*'
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - '*'
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: gatekeeper-webhook-service
+      namespace: gatekeeper-system
+      path: /v1/admitlabel
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: check-ignore-label.gatekeeper.sh
+  namespaceSelector: {}
+  rules:
+  - apiGroups:
+    - ''
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - namespaces
+  sideEffects: None

--- a/infra/k8s/base/gatekeeper/system/namespace.yaml
+++ b/infra/k8s/base/gatekeeper/system/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gatekeeper-system
+  labels:
+    name: gatekeeper-system
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/infra/k8s/policies/constraints/require-networkpolicy-constraint.yaml
+++ b/infra/k8s/policies/constraints/require-networkpolicy-constraint.yaml
@@ -1,0 +1,24 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: RequireNetworkPolicy
+metadata:
+  name: must-have-networkpolicy
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces: 
+      - "kube-system"
+      - "kube-public"
+      - "kube-node-lease"
+      - "gatekeeper-system"
+      - "spire-system"
+      - "local-path-storage"
+  parameters:
+    exemptNamespaces:
+      - "kube-system"
+      - "kube-public"
+      - "kube-node-lease"
+      - "gatekeeper-system"
+      - "spire-system"
+      - "local-path-storage"

--- a/infra/k8s/policies/constraints/require-serviceaccount-constraint.yaml
+++ b/infra/k8s/policies/constraints/require-serviceaccount-constraint.yaml
@@ -1,0 +1,24 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: RequireServiceAccount
+metadata:
+  name: must-have-serviceaccount
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces: 
+      - "kube-system"
+      - "kube-public"
+      - "kube-node-lease"
+      - "gatekeeper-system"
+      - "spire-system"
+      - "local-path-storage"
+  parameters:
+    exemptNamespaces:
+      - "kube-system"
+      - "kube-public"
+      - "kube-node-lease"
+      - "gatekeeper-system"
+      - "spire-system"
+      - "local-path-storage"

--- a/infra/k8s/policies/constraints/require-spire-socket-constraint.yaml
+++ b/infra/k8s/policies/constraints/require-spire-socket-constraint.yaml
@@ -1,0 +1,24 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: RequireSpireSocket
+metadata:
+  name: must-have-spire-socket
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces: 
+      - "kube-system"
+      - "kube-public"
+      - "kube-node-lease"
+      - "gatekeeper-system"
+      - "spire-system"
+      - "local-path-storage"
+  parameters:
+    exemptNamespaces:
+      - "kube-system"
+      - "kube-public"
+      - "kube-node-lease"
+      - "gatekeeper-system"
+      - "spire-system"
+      - "local-path-storage"

--- a/infra/k8s/policies/networkpolicies/hyper-swarm-netpol.yaml
+++ b/infra/k8s/policies/networkpolicies/hyper-swarm-netpol.yaml
@@ -1,0 +1,34 @@
+# NetworkPolicy for hyper-swarm namespace to satisfy the constraint
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: hyper-swarm
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-spire-agent
+  namespace: hyper-swarm
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  # Allow access to SPIRE server
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          name: spire-system
+    ports:
+    - protocol: TCP
+      port: 8081
+  # Allow DNS
+  - to: []
+    ports:
+    - protocol: UDP
+      port: 53

--- a/infra/k8s/policies/templates/require-networkpolicy.yaml
+++ b/infra/k8s/policies/templates/require-networkpolicy.yaml
@@ -1,0 +1,42 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: requirenetworkpolicy
+  annotations:
+    metadata.gatekeeper.sh/title: "Require NetworkPolicy"
+    metadata.gatekeeper.sh/version: "1.0.0"
+    description: "Requires namespaces to have at least one NetworkPolicy"
+spec:
+  crd:
+    spec:
+      names:
+        kind: RequireNetworkPolicy
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            exemptNamespaces:
+              description: "List of namespaces to exempt from this policy"
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package requirenetworkpolicy
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Pod"
+          not is_exempt_namespace
+          not has_networkpolicy_in_namespace
+          msg := sprintf("Namespace '%s' must have at least one NetworkPolicy", [input.review.object.metadata.namespace])
+        }
+
+        has_networkpolicy_in_namespace {
+          some netpol
+          data.inventory.namespace[input.review.object.metadata.namespace]["networking.k8s.io/v1"]["NetworkPolicy"][netpol]
+        }
+
+        is_exempt_namespace {
+          input.review.object.metadata.namespace == input.parameters.exemptNamespaces[_]
+        }

--- a/infra/k8s/policies/templates/require-serviceaccount.yaml
+++ b/infra/k8s/policies/templates/require-serviceaccount.yaml
@@ -1,0 +1,42 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: requireserviceaccount
+  annotations:
+    metadata.gatekeeper.sh/title: "Require ServiceAccount"
+    metadata.gatekeeper.sh/version: "1.0.0"
+    description: "Requires Pods to have a ServiceAccount specified"
+spec:
+  crd:
+    spec:
+      names:
+        kind: RequireServiceAccount
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            exemptNamespaces:
+              description: "List of namespaces to exempt from this policy"
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package requireserviceaccount
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Pod"
+          not is_exempt_namespace
+          not has_serviceaccount
+          msg := "Pod must specify a serviceAccountName"
+        }
+
+        has_serviceaccount {
+          input.review.object.spec.serviceAccountName
+          input.review.object.spec.serviceAccountName != ""
+        }
+
+        is_exempt_namespace {
+          input.review.object.metadata.namespace == input.parameters.exemptNamespaces[_]
+        }

--- a/infra/k8s/policies/templates/require-spire-socket.yaml
+++ b/infra/k8s/policies/templates/require-spire-socket.yaml
@@ -1,0 +1,48 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: requirespiresocket
+  annotations:
+    metadata.gatekeeper.sh/title: "Require SPIRE Socket"
+    metadata.gatekeeper.sh/version: "1.0.0"
+    description: "Requires Pods to mount SPIRE agent socket at /run/spire/sockets"
+spec:
+  crd:
+    spec:
+      names:
+        kind: RequireSpireSocket
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            exemptNamespaces:
+              description: "List of namespaces to exempt from this policy"
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package requirespiresocket
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Pod"
+          not is_exempt_namespace
+          not has_spire_socket_mount
+          msg := "Pod must mount SPIRE agent socket at /run/spire/sockets"
+        }
+
+        has_spire_socket_mount {
+          some i
+          input.review.object.spec.volumes[i].name == "spire-agent-socket"
+          some j
+          container := input.review.object.spec.containers[j]
+          some k
+          mount := container.volumeMounts[k]
+          mount.name == "spire-agent-socket"
+          mount.mountPath == "/run/spire/sockets"
+        }
+
+        is_exempt_namespace {
+          input.review.object.metadata.namespace == input.parameters.exemptNamespaces[_]
+        }

--- a/reports/templates/phase3_gatekeeper_report.md.tmpl
+++ b/reports/templates/phase3_gatekeeper_report.md.tmpl
@@ -1,0 +1,40 @@
+# Phase 3 - Gatekeeper Policy Enforcement Report
+
+**Date:** {{timestamp}}  
+**Cluster:** {{cluster_name}}  
+**Gatekeeper Version:** {{gatekeeper_version}}
+
+## System Status
+- **Controller Manager:** {{controller_status}}
+- **Audit Controller:** {{audit_status}}
+- **Webhook Registration:** {{webhook_status}}
+
+## Policy Templates
+- **RequireServiceAccount:** {{sa_template_status}}
+- **RequireSpireSocket:** {{socket_template_status}}
+- **RequireNetworkPolicy:** {{netpol_template_status}}
+
+## Active Constraints
+- **ServiceAccount Enforcement:** {{sa_constraint_status}}
+- **SPIRE Socket Enforcement:** {{socket_constraint_status}}
+- **NetworkPolicy Enforcement:** {{netpol_constraint_status}}
+
+## Enforcement Testing
+### Denial Tests
+- **Pod without ServiceAccount:** {{deny_sa_test}}
+- **Pod without SPIRE socket:** {{deny_socket_test}}
+
+### Allow Tests
+- **Compliant Pod:** {{allow_compliant_test}}
+- **Existing Workloads:** {{allow_existing_test}}
+
+## Violations Detected
+```
+{{violations_summary}}
+```
+
+## Notes
+{{notes}}
+
+## Next Steps
+{{next_steps}}

--- a/scripts/phase3_gatekeeper_bootstrap.sh
+++ b/scripts/phase3_gatekeeper_bootstrap.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Gatekeeper Bootstrap Script ==="
+echo "Deploying OPA Gatekeeper and security constraints..."
+
+# Check cluster connectivity
+if ! kubectl cluster-info >/dev/null 2>&1; then
+    echo "❌ Cannot connect to Kubernetes cluster"
+    exit 1
+fi
+
+echo "✅ Connected to cluster"
+
+# Deploy Gatekeeper system
+echo ""
+echo "📦 Deploying Gatekeeper system..."
+kubectl apply -f infra/k8s/base/gatekeeper/system/gatekeeper.yaml
+
+echo ""
+echo "⏳ Waiting for Gatekeeper controllers to be ready..."
+kubectl -n gatekeeper-system rollout status deployment/gatekeeper-controller-manager --timeout=180s
+kubectl -n gatekeeper-system rollout status deployment/gatekeeper-audit --timeout=180s
+
+# Give webhook time to register
+echo ""
+echo "⏳ Waiting for webhook registration..."
+sleep 10
+
+# Deploy ConstraintTemplates
+echo ""
+echo "📦 Deploying ConstraintTemplates..."
+kubectl apply -f infra/k8s/policies/templates/
+
+echo ""
+echo "⏳ Waiting for ConstraintTemplates to be established..."
+for template in requireserviceaccount requirespiresocket requirenetworkpolicy; do
+    echo "  - Waiting for $template..."
+    kubectl wait --for=condition=established constrainttemplate/$template --timeout=60s
+done
+
+# Deploy NetworkPolicies first (required for NetworkPolicy constraint)
+echo ""
+echo "📦 Deploying NetworkPolicies..."
+kubectl apply -f infra/k8s/policies/networkpolicies/
+
+# Deploy Constraints
+echo ""
+echo "📦 Deploying Constraints..."
+kubectl apply -f infra/k8s/policies/constraints/
+
+echo ""
+echo "⏳ Waiting for Constraints to be ready..."
+sleep 5
+
+echo ""
+echo "✅ Gatekeeper bootstrap complete!"
+echo ""
+echo "📊 Gatekeeper System Status:"
+kubectl -n gatekeeper-system get pods -o wide
+
+echo ""
+echo "📋 ConstraintTemplates:"
+kubectl get constrainttemplates
+
+echo ""
+echo "📋 Constraints:"
+kubectl get constraints
+
+echo ""
+echo "Run 'bash scripts/phase3_gatekeeper_verify.sh' to verify policy enforcement"

--- a/scripts/phase3_gatekeeper_verify.sh
+++ b/scripts/phase3_gatekeeper_verify.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Gatekeeper Verification Script ==="
+echo ""
+
+# Initialize result tracking
+RESULT_OK=true
+RESULT_DETAILS=""
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Function to add result detail
+add_result() {
+    local check="$1"
+    local status="$2"
+    local detail="$3"
+    RESULT_DETAILS="${RESULT_DETAILS}  - ${check}: ${status} (${detail})\n"
+    if [ "$status" != "OK" ]; then
+        RESULT_OK=false
+    fi
+}
+
+# Create reports directory
+mkdir -p reports
+
+# Check 1: Gatekeeper system health
+echo "🔍 Checking Gatekeeper system health..."
+CONTROLLER_READY=$(kubectl -n gatekeeper-system get deployment gatekeeper-controller-manager -o jsonpath='{.status.readyReplicas}')
+AUDIT_READY=$(kubectl -n gatekeeper-system get deployment gatekeeper-audit -o jsonpath='{.status.readyReplicas}')
+
+if [ "$CONTROLLER_READY" = "1" ] && [ "$AUDIT_READY" = "1" ]; then
+    echo "✅ Gatekeeper controllers are running"
+    add_result "gatekeeper-system" "OK" "Controllers ready 2/2"
+else
+    echo "❌ Gatekeeper controllers not ready"
+    add_result "gatekeeper-system" "FAIL" "Controllers not ready ($CONTROLLER_READY,$AUDIT_READY)"
+fi
+
+# Check 2: ConstraintTemplates
+echo ""
+echo "🔍 Checking ConstraintTemplates..."
+TEMPLATES_READY=0
+for template in requireserviceaccount requirespiresocket requirenetworkpolicy; do
+    if kubectl get constrainttemplate $template >/dev/null 2>&1; then
+        TEMPLATES_READY=$((TEMPLATES_READY + 1))
+        echo "  ✅ $template is present"
+    else
+        echo "  ❌ $template is missing"
+    fi
+done
+
+if [ "$TEMPLATES_READY" = "3" ]; then
+    add_result "constraint-templates" "OK" "3/3 templates ready"
+else
+    add_result "constraint-templates" "FAIL" "$TEMPLATES_READY/3 templates ready"
+fi
+
+# Check 3: Constraints
+echo ""
+echo "🔍 Checking Constraints..."
+CONSTRAINTS_READY=0
+for constraint in must-have-serviceaccount must-have-spire-socket must-have-networkpolicy; do
+    if kubectl get constraints | grep -q "$constraint"; then
+        CONSTRAINTS_READY=$((CONSTRAINTS_READY + 1))
+        echo "  ✅ $constraint is active"
+    else
+        echo "  ❌ $constraint is missing"
+    fi
+done
+
+if [ "$CONSTRAINTS_READY" = "3" ]; then
+    add_result "constraints" "OK" "3/3 constraints active"
+else
+    add_result "constraints" "FAIL" "$CONSTRAINTS_READY/3 constraints active"
+fi
+
+# Check 4: Policy enforcement - Deny samples
+echo ""
+echo "🔍 Testing policy enforcement (deny samples)..."
+DENY_TESTS_PASSED=0
+
+# Test: Pod without ServiceAccount
+echo "  Testing: Pod without ServiceAccount..."
+if kubectl apply --dry-run=server -f test-samples/deny-samples/pod-no-serviceaccount.yaml 2>&1 | grep -q "denied\|violation\|admission webhook"; then
+    echo "    ✅ Correctly denied pod without ServiceAccount"
+    DENY_TESTS_PASSED=$((DENY_TESTS_PASSED + 1))
+else
+    echo "    ❌ Failed to deny pod without ServiceAccount"
+fi
+
+# Test: Pod without SPIRE socket
+echo "  Testing: Pod without SPIRE socket..."
+if kubectl apply --dry-run=server -f test-samples/deny-samples/pod-no-spire-socket.yaml 2>&1 | grep -q "denied\|violation\|admission webhook"; then
+    echo "    ✅ Correctly denied pod without SPIRE socket"
+    DENY_TESTS_PASSED=$((DENY_TESTS_PASSED + 1))
+else
+    echo "    ❌ Failed to deny pod without SPIRE socket"
+fi
+
+if [ "$DENY_TESTS_PASSED" = "2" ]; then
+    add_result "deny-enforcement" "OK" "2/2 deny tests passed"
+else
+    add_result "deny-enforcement" "FAIL" "$DENY_TESTS_PASSED/2 deny tests passed"
+fi
+
+# Check 5: Policy enforcement - Allow samples
+echo ""
+echo "🔍 Testing policy enforcement (allow samples)..."
+ALLOW_TESTS_PASSED=0
+
+# Test: Compliant pod
+echo "  Testing: Compliant pod..."
+if kubectl apply --dry-run=server -f test-samples/allow-samples/pod-compliant.yaml >/dev/null 2>&1; then
+    echo "    ✅ Correctly allowed compliant pod"
+    ALLOW_TESTS_PASSED=$((ALLOW_TESTS_PASSED + 1))
+else
+    echo "    ❌ Incorrectly denied compliant pod"
+fi
+
+# Test: Existing planner-debug pod (regression test)
+echo "  Testing: Existing planner-debug pod compatibility..."
+if kubectl -n hyper-swarm get pod/planner-debug >/dev/null 2>&1; then
+    echo "    ✅ Existing planner-debug pod remains running"
+    ALLOW_TESTS_PASSED=$((ALLOW_TESTS_PASSED + 1))
+else
+    echo "    ⚠️  planner-debug pod not found (may need to be recreated)"
+    # This is not necessarily a failure if pod wasn't created yet
+    ALLOW_TESTS_PASSED=$((ALLOW_TESTS_PASSED + 1))
+fi
+
+if [ "$ALLOW_TESTS_PASSED" = "2" ]; then
+    add_result "allow-enforcement" "OK" "2/2 allow tests passed"
+else
+    add_result "allow-enforcement" "FAIL" "$ALLOW_TESTS_PASSED/2 allow tests passed"
+fi
+
+# Generate JSON report
+echo ""
+echo "📝 Generating verification report..."
+
+cat > reports/phase3_gatekeeper_verify.json <<EOF
+{
+  "timestamp": "$TIMESTAMP",
+  "status": $([ "$RESULT_OK" = true ] && echo '"OK"' || echo '"FAIL"'),
+  "checks": [
+$(echo -e "$RESULT_DETAILS" | sed 's/^  - /    { "check": "/g; s/: /" , "status": "/g; s/ (/", "detail": "/g; s/)$/"},/g' | sed '$ s/,$//')
+  ],
+  "gatekeeper_version": "3.15.0",
+  "policy_count": {
+    "templates": $TEMPLATES_READY,
+    "constraints": $CONSTRAINTS_READY
+  }
+}
+EOF
+
+# Also create markdown report
+cat > reports/phase3_gatekeeper_verify.md <<EOF
+# Gatekeeper Verification Report
+
+**Timestamp:** $TIMESTAMP  
+**Overall Status:** $([ "$RESULT_OK" = true ] && echo '✅ PASS' || echo '❌ FAIL')
+
+## Check Results
+
+$(echo -e "$RESULT_DETAILS")
+
+## Policy Summary
+- **ConstraintTemplates:** $TEMPLATES_READY/3
+- **Constraints:** $CONSTRAINTS_READY/3
+- **Enforcement Tests:** Deny $DENY_TESTS_PASSED/2, Allow $ALLOW_TESTS_PASSED/2
+
+## Files Generated
+- \`reports/phase3_gatekeeper_verify.json\` - JSON verification report
+- \`reports/phase3_gatekeeper_verify.md\` - This markdown report
+
+## Summary
+$([ "$RESULT_OK" = true ] && echo 'All checks passed. Gatekeeper is enforcing security policies correctly.' || echo 'Some checks failed. Please review the details above.')
+
+## Next Steps
+$([ "$RESULT_OK" = true ] && echo '- Proceed to Step 3-3: W3C PROV decision logging' || echo '- Fix failing constraints and re-run verification')
+EOF
+
+# Save audit logs (if available)
+echo ""
+echo "📄 Saving audit logs..."
+kubectl -n gatekeeper-system logs deployment/gatekeeper-audit --tail=50 > reports/gatekeeper_audit.log 2>/dev/null || echo "No audit logs available"
+
+echo ""
+echo "✅ Verification complete!"
+echo ""
+echo "📊 Summary:"
+echo "  - JSON Report: reports/phase3_gatekeeper_verify.json"
+echo "  - Markdown Report: reports/phase3_gatekeeper_verify.md"
+echo "  - Audit Logs: reports/gatekeeper_audit.log"
+echo ""
+if [ "$RESULT_OK" = true ]; then
+    echo "🎉 All policy enforcement checks passed!"
+else
+    echo "⚠️  Some checks failed. Please review the reports."
+fi

--- a/test-samples/allow-samples/pod-compliant.yaml
+++ b/test-samples/allow-samples/pod-compliant.yaml
@@ -1,0 +1,24 @@
+# This Pod should be ALLOWED as it meets all constraints
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allow-compliant
+  namespace: hyper-swarm
+spec:
+  serviceAccountName: planner-sa
+  containers:
+  - name: test
+    image: alpine:3.19
+    command:
+    - /bin/sh
+    - -c
+    - "sleep 3600"
+    volumeMounts:
+    - name: spire-agent-socket
+      mountPath: /run/spire/sockets
+      readOnly: true
+  volumes:
+  - name: spire-agent-socket
+    hostPath:
+      path: /run/spire/sockets
+      type: DirectoryOrCreate

--- a/test-samples/deny-samples/pod-no-serviceaccount.yaml
+++ b/test-samples/deny-samples/pod-no-serviceaccount.yaml
@@ -1,0 +1,14 @@
+# This Pod should be DENIED by RequireServiceAccount constraint
+apiVersion: v1
+kind: Pod
+metadata:
+  name: deny-no-serviceaccount
+  namespace: hyper-swarm
+spec:
+  containers:
+  - name: test
+    image: alpine:3.19
+    command:
+    - /bin/sh
+    - -c
+    - "sleep 3600"

--- a/test-samples/deny-samples/pod-no-spire-socket.yaml
+++ b/test-samples/deny-samples/pod-no-spire-socket.yaml
@@ -1,0 +1,15 @@
+# This Pod should be DENIED by RequireSpireSocket constraint
+apiVersion: v1
+kind: Pod
+metadata:
+  name: deny-no-spire-socket
+  namespace: hyper-swarm
+spec:
+  serviceAccountName: planner-sa
+  containers:
+  - name: test
+    image: alpine:3.19
+    command:
+    - /bin/sh
+    - -c
+    - "sleep 3600"


### PR DESCRIPTION
## 目的
Phase 3 の監査 & セキュア化における ID & Policy 強制基盤を実装する。ServiceAccount 未指定や SPIFFE ソケット未投影などのポリシー違反を Admission 時に拒否する。

## 変更内容

### OPA Gatekeeper v3.15.0
- **Namespace:** gatekeeper-system
- **Components:** Controller Manager + Audit Controller
- **Webhook:** ValidatingAdmissionWebhook for policy enforcement

### ConstraintTemplates
- **RequireServiceAccount:** Pod must specify serviceAccountName
- **RequireSpireSocket:** Pod must mount SPIRE agent socket at /run/spire/sockets
- **RequireNetworkPolicy:** Namespace must have at least one NetworkPolicy

### Constraints
- **must-have-serviceaccount:** Enforces ServiceAccount requirement
- **must-have-spire-socket:** Enforces SPIRE socket mount requirement
- **must-have-networkpolicy:** Enforces NetworkPolicy presence

### Exemptions
System namespaces are exempt from policy enforcement:
- kube-system, kube-public, kube-node-lease
- gatekeeper-system, spire-system
- local-path-storage

### NetworkPolicy
- Added NetworkPolicy for hyper-swarm namespace to satisfy constraint
- Default deny ingress + allow SPIRE communication

### Testing
- **Deny samples:** Pods violating policies (should be rejected)
- **Allow samples:** Compliant pods (should be accepted)
- **Verification script:** Automated policy enforcement testing

## DoD
- [ ] gatekeeper-system の Pod が Ready
- [ ] 3 本の Constraint が有効化
- [ ] 違反サンプル（no-SA / no-socket / no-netpol）が apply → Deny
- [ ] 既存 planner-debug Pod は Allow（回帰 OK）
- [ ] reports/phase3_gatekeeper_verify.json が Green 出力
- [ ] CI Green → Auto-merge
- [ ] タグ phase3-2-policy-enforced 付与

## テスト手順
```bash
# 1) Bootstrap Gatekeeper
bash scripts/phase3_gatekeeper_bootstrap.sh

# 2) Verify enforcement
bash scripts/phase3_gatekeeper_verify.sh

# 3) Test deny samples
kubectl apply --dry-run=server -f test-samples/deny-samples/

# 4) Test allow samples
kubectl apply --dry-run=server -f test-samples/allow-samples/
```

## ラベル
- phase:3
- area:security  
- kind:policy