### PR TITLE
docs(p6): Runbook Freeze/Guard + Alerts一覧

### DIFF
--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -1,0 +1,11 @@
+# Alerts (SLO 99.9%)
+
+| Alert | 窓 | Burn rate 目安 | Severity | 概要 |
+|---|---:|---:|---|---|
+| **SLOFastBurn**  | 5m  | ≈14.4x | page   | 急速消費（2時間で枯渇相当） |
+| **SLOSlowBurn**  | 30m | ≈6x    | ticket | 漸進消費（数日で枯渇相当） |
+| **SLOTrendWarn** | 1h  | ≈3x    | warn   | トレンド警告（注意喚起） |
+
+- **Runbook**: `docs/runbooks/http_slo_999.md`  
+- **Alertmanager（dev）**: Webhook ロガー/コンソール  
+- **Alertmanager（prod）**: Slack/Oncall/Pager などへルーティング

--- a/docs/runbooks/http_slo_999.md
+++ b/docs/runbooks/http_slo_999.md
@@ -1,0 +1,18 @@
+# HTTP SLO 99.9% Runbook
+
+## Deploy Freeze / Unfreeze
+- **Freeze 有効化**  
+  - `echo '{"freeze": true}' > .ops/deploy_freeze.json`  
+  - PR 作成 → Auto-merge で **CD 停止**
+- **Unfreeze（解除）**  
+  - `echo '{"freeze": false}' > .ops/deploy_freeze.json`  
+  - PR 作成 → Auto-merge で **CD 再開**
+
+## Post-Promotion Guard 初動
+- **Guard 失敗時の自動動作**: ロールバック → Freeze → GitHub Issue 自動起票  
+- **当面の運用**  
+  1) Issue を確認（関連ログ/証跡のリンクを参照）  
+  2) 原因対処（設定/リソース/容量など）  
+  3) `Unfreeze` PR を作成 → CI green → Auto-merge で CD を再開  
+  4) 失敗再現テスト → Canary 昇格の再試行
+


### PR DESCRIPTION
### Runbook に Freeze/Guard 初動を追補し、SLO アラート一覧を追加

## 追加内容

### docs/runbooks/http_slo_999.md
- **Deploy Freeze/Unfreeze 手順**
  - Freeze 有効化: CD パイプライン停止手順
  - Unfreeze: CD パイプライン再開手順
- **Post-Promotion Guard 初動対応**
  - Guard 失敗時の自動動作フロー
  - 運用手順 (Issue確認 → 原因対処 → Unfreeze → 再試行)

### docs/alerts.md (新規)
- **SLO 99.9% アラート一覧**
  - SLOFastBurn: 5分窓 (≈14.4x burn rate) - page severity
  - SLOSlowBurn: 30分窓 (≈6x burn rate) - ticket severity  
  - SLOTrendWarn: 1時間窓 (≈3x burn rate) - warn severity
- **Runbook リンク**: `docs/runbooks/http_slo_999.md`
- **Alertmanager ルーティング**: dev (Webhook) / prod (Slack/Oncall/Pager)

## 目的
Phase 6 の運用強化に向けて、インシデント対応手順とアラート体系を明文化

🤖 Generated with [Claude Code](https://claude.ai/code)