### PR TITLE
docs(p6): multicluster & edge failover

### DIFF
--- a/docs/edge/failover.md
+++ b/docs/edge/failover.md
@@ -1,0 +1,38 @@
+# Edge Failover（HAProxy / dev 実演）
+
+**目的**: dev 環境で Edge L7（HAProxy）により **cluster-a → cluster-b** の自動切替（active/backup）を検証する。
+
+## 1. エンドポイント
+- **Edge**: `http://localhost:30080/hello`（統一入口）
+- **Backend**:
+  - cluster-a: `http://localhost:31380/hello`（primary）
+  - cluster-b: `http://localhost:32380/hello`（backup）
+- **ダッシュボード**: `http://localhost:30090/stats`
+
+## 2. 起動
+```bash
+bash scripts/phase5_failover_bootstrap.sh
+# HAProxy (:30080 / :30090) が立ち上がり、/hello 200 を返すことを確認
+```
+
+## 3. フェイルオーバー演習
+```bash
+bash scripts/phase5_failover_verify.sh
+# 手順: aのingress停止 → 連続200検出 → RTO測定 → 品質(成功率/latency)測定 → a回復
+# 判定: RTO ≤ 60s / success ≥ 95% / p50 < 1000ms
+# 結果: reports/phase5_failover_result.json / スナップショット md
+```
+
+## 4. 本番置換（参考）
+- HAProxy on localhost は **実演用**。本番は **GSLB/DNS/Edge LB** に置換
+- 監視は **L7 ヘルスチェック**（2xx）＋リージョン/ゾーン重み付け
+- 切替フローは **RTO/RPO 要件**に合わせて閾値/ヒステリシスを調整
+
+## 5. トラブルシュート
+- **/hello が 200 にならない**: NodePort 設定（31380/32380）と HTTPRoute を確認
+- **スクリプト失敗時**: `A_CTX/A_NS/A_DEP` の環境変数を明示
+
+## 6. 検証基準
+- **RTO**: ≤ 60 秒（フェイルオーバー時間）
+- **成功率**: ≥ 95%（継続サービス提供）
+- **レイテンシ**: P50 < 1000ms（性能維持）

--- a/docs/multicluster/apps.md
+++ b/docs/multicluster/apps.md
@@ -1,0 +1,44 @@
+# Multi-Cluster GitOps (Argo CD ApplicationSet)
+
+本書は **cluster-a / cluster-b** を Argo CD に登録し、**ApplicationSet** で `infra/gitops/apps/` を両クラスタへ同期する運用手順の要点をまとめる。
+
+## 1. 事前準備
+- Argo CD サーバ稼働（`argocd` NS）
+- 2 クラスタ（例: `kind-cluster-a`, `kind-cluster-b`）に到達できる kubeconfig
+
+## 2. クラスタ登録 & ラベル
+```bash
+# 例: CLI で登録（self-hosted runner から）
+argocd cluster add kind-cluster-a --name cluster-a --yes
+argocd cluster add kind-cluster-b --name cluster-b --yes
+
+# Cluster Secret に region ラベルを付与（ApplicationSet の selector で使用）
+kubectl -n argocd label secret $(kubectl -n argocd get secret -l argocd.argoproj.io/secret-type=cluster -o name | grep cluster-a) region=a --overwrite
+kubectl -n argocd label secret $(kubectl -n argocd get secret -l argocd.argoproj.io/secret-type=cluster -o name | grep cluster-b) region=b --overwrite
+```
+
+## 3. NodePort 差別化（dev/kind）
+- **cluster-a**: 31380（ingressgateway:80）
+- **cluster-b**: 32380（ingressgateway:80）
+
+```bash
+# 例: cluster-b の NodePort を 32380 にパッチ
+kubectl --context kind-cluster-b -n istio-system patch svc istio-ingressgateway   -p '{"spec":{"ports":[{"name":"http2","port":80,"nodePort":32380}]}}'
+```
+
+## 4. ApplicationSet 設定
+- **パス**: `infra/gitops/appset/`
+- **ジェネレータ**: `clusters.selector.matchExpressions` で `region ∈ {a,b}`
+- **テンプレート**: `root-app-{{name}}` を自動生成（path: `infra/gitops/apps` を同期）
+
+## 5. 検証（スクリプト）
+```bash
+bash scripts/phase5_appset_verify.sh
+# 期待: JSON に synced=true / healthy=true / a_http_200=true / b_http_200=true
+#       http://localhost:31380/hello / http://localhost:32380/hello が 200
+```
+
+## 6. 運用ポイント
+- **新クラスタ**: label 付与だけで自動検出（ゼロタッチ展開）
+- **重大事故時**: cluster-a/b を独立運用しつつ GitOps 状態は ApplicationSet が担保
+- **監査**: `reports/phase5_appset_verify.json` を証跡として保存


### PR DESCRIPTION
### ApplicationSet（multi-cluster）と Edge/Failover（HAProxy）の手順書を追加

## 追加内容

### docs/multicluster/apps.md (新規)
**Multi-Cluster GitOps 運用手順:**
- Argo CD ApplicationSet によるマルチクラスター管理
- クラスタ登録とラベル付与（region=a/b）
- NodePort差別化（31380/32380）
- ゼロタッチ展開とGitOps状態管理
- 検証スクリプト: `scripts/phase5_appset_verify.sh`

### docs/edge/failover.md (新規)  
**Edge L7 フェイルオーバー実演:**
- HAProxy による cluster-a → cluster-b 自動切替
- エンドポイント: localhost:30080 (統一入口)
- 演習手順: 障害注入 → RTO測定 → 品質評価
- 検証基準: RTO≤60s, 成功率≥95%, P50<1000ms
- 本番GSLB/DNS置換への移行指針

## 運用ポイント
- **マルチクラスター**: ApplicationSetによるゼロタッチ展開
- **フェイルオーバー**: 自動切替とSLA維持
- **監査証跡**: JSON形式での結果保存

## 目的
Phase 6 のグローバル配信基盤（マルチクラスター + エッジ）の運用手順を明文化

🤖 Generated with [Claude Code](https://claude.ai/code)