### PR TITLE
docs(p6): SSOT追補 + incident template

### DIFF
--- a/.github/ISSUE_TEMPLATE/incident.md
+++ b/.github/ISSUE_TEMPLATE/incident.md
@@ -1,0 +1,46 @@
+---
+name: Incident Report
+about: Post-Guard failure / SLO alert firing
+title: "[INCIDENT] <short summary>"
+labels: incident
+assignees: ""
+---
+
+## 概要
+- **事象開始**: <!-- JST/UTC -->
+- **影響範囲**: <!-- users/requests/services -->
+- **監視イベント**: <!-- SLOFastBurn / SlowBurn / Guard NG など -->
+
+## 初動 / 一時対応
+- **切戻し / Freeze 実施**: <!-- yes/no & 時刻 -->
+- **連絡**: <!-- oncall/slack -->
+
+## 技術詳細
+- **直近の変更**: <!-- PR/タグ -->
+- **メトリクス**: <!-- p50/p95/success/CPU/Mem など -->
+- **ログ断片**: <!-- 重要行リンク or 添付 -->
+
+## 原因分析（仮説 → 確定）
+- **根本原因**:
+- **再発条件**:
+
+## 対応
+- **暫定対応**:
+- **恒久対応**:
+- **解除手順（Unfreeze など）**:
+
+## 証跡リンク
+- **reports/phase5_cd_guard_result.json**:
+- **reports/phase4_canary_promotion.json**:
+- **dashboards / runbooks**:
+
+## Timeline
+| 時刻 | 事象 | 対応者 |
+|------|------|--------|
+|      |      |        |
+
+## Post-Mortem
+- [ ] 根本原因特定完了
+- [ ] 恒久対策実施完了  
+- [ ] Runbook/Alert 改善完了
+- [ ] チーム共有完了


### PR DESCRIPTION
### Phase 5+ の運用ループ（Canary/Guard/Freeze/MC GitOps/Failover）をSSOTに追補し、インシデント票テンプレを追加

## 更新内容

### diagrams/src/ops_single_source_of_truth_v1.md
**Phase 5+ 運用ループ追補:**
- Mermaid フローチャートで CD/GitOps/Edge の関係を視覚化
- Canary 昇格: 90/10 → 50/50 → 100/0 (SLOゲート通過)
- Post-Guard: 監視ウィンドウでSLO再評価 (NG → Rollback + Freeze + Issue)
- Multi-Cluster GitOps: ApplicationSet による a/b クラスタ同期
- Edge Failover: HAProxy/DNS による自動切替

### .github/ISSUE_TEMPLATE/incident.md (新規)
**インシデント管理テンプレート:**
- 概要: 事象開始時刻、影響範囲、監視イベント
- 初動対応: 切戻し/Freeze実施、連絡体制
- 技術詳細: 直近変更、メトリクス、ログ
- 原因分析: 根本原因、再発条件
- 対応手順: 暫定/恒久対応、Unfreeze手順
- 証跡リンク: JSON結果、ダッシュボード、Runbook
- Timeline: 時系列での事象記録
- Post-Mortem: チェックリスト形式

## 目的
Phase 6 のインシデント管理体制強化とSSOTの運用ループ明文化

🤖 Generated with [Claude Code](https://claude.ai/code)