### PR TITLE
chore(docs): add SSOT link

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,4 @@ open http://localhost:3000  # (admin/admin)
 - ArgoCD GitOps デプロイメント基盤
 - A/B テスト評価枠組み構築
 - 800 cells/sec 大規模負荷耐性確立
+- SSOT（運用ループの全体図）: `diagrams/src/ops_single_source_of_truth_v1.md`


### PR DESCRIPTION
### READMEから最新版SSOT図へ誘導

## 追加内容
- README.md に SSOT（運用ループの全体図）へのリンク追加
- パス: `diagrams/src/ops_single_source_of_truth_v1.md`
- Phase 5+ の運用ループ（CD/Guard/Freeze/Multi-Cluster/Failover）を含む最新版

## 目的  
ドキュメント体系の整理とSSOTへのアクセス向上

🤖 Generated with [Claude Code](https://claude.ai/code)