### PR TITLE
docs: add Docs Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,4 @@ open http://localhost:3000  # (admin/admin)
 - A/B テスト評価枠組み構築
 - 800 cells/sec 大規模負荷耐性確立
 - SSOT（運用ループの全体図）: `diagrams/src/ops_single_source_of_truth_v1.md`
+- ドキュメント目次: `docs/README.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Docs Index
+
+- **SLO Runbook**: docs/runbooks/http_slo_999.md
+- **Alerts (SLO 99.9%)**: docs/alerts.md
+- **CD Canary Pipeline**: docs/cd/canary_pipeline.md
+- **Multi-Cluster (ApplicationSet)**: docs/multicluster/apps.md
+- **Edge Failover (HAProxy/dev)**: docs/edge/failover.md
+- **SSOT 図**: diagrams/src/ops_single_source_of_truth_v1.md


### PR DESCRIPTION
### Phase 6向けドキュメントの索引ページ（docs/README.md）を追加し、ルートREADMEから誘導

## 追加内容

### docs/README.md (新規)
**Phase 6 ドキュメント索引:**
- SLO Runbook: docs/runbooks/http_slo_999.md
- Alerts (SLO 99.9%): docs/alerts.md
- CD Canary Pipeline: docs/cd/canary_pipeline.md
- Multi-Cluster (ApplicationSet): docs/multicluster/apps.md
- Edge Failover (HAProxy/dev): docs/edge/failover.md
- SSOT 図: diagrams/src/ops_single_source_of_truth_v1.md

### README.md 更新
- ドキュメント目次へのリンク追加: `docs/README.md`
- 重複回避でクリーンに配置

## 目的
Phase 6 の運用ドキュメント体系を整理し、アクセス性を向上

🤖 Generated with [Claude Code](https://claude.ai/code)