### PR TITLE
chore(p6-5): snapshot (docs index)

### DIFF
--- a/reports/snap_p6-5_docs_index.md
+++ b/reports/snap_p6-5_docs_index.md
@@ -1,0 +1,27 @@
+⏺ ✅ Docs Index 追加
+
+Date: 2025-08-29T02:16:30Z
+Commit: 06150c6
+
+## 追加内容
+
+### docs/README.md (新規)
+**Phase 6 ドキュメント索引:**
+- SLO Runbook: docs/runbooks/http_slo_999.md
+- Alerts (SLO 99.9%): docs/alerts.md  
+- CD Canary Pipeline: docs/cd/canary_pipeline.md
+- Multi-Cluster (ApplicationSet): docs/multicluster/apps.md
+- Edge Failover (HAProxy/dev): docs/edge/failover.md
+- SSOT 図: diagrams/src/ops_single_source_of_truth_v1.md
+
+### README.md 更新
+- ドキュメント目次へのリンク: `docs/README.md`
+- 重複回避でクリーンに配置
+
+## ドキュメント体系
+Phase 6 の運用ドキュメントを整理し、アクセス性向上:
+- 中央索引による統一的なナビゲーション
+- 各ドキュメントの役割と位置づけを明確化
+- ルート README からのスムーズな誘導
+
+→ Phase 6 ドキュメント体系 整備完了


### PR DESCRIPTION
### Docs Index 追加のスナップショット

Phase 6 ドキュメント体系整備の記録:
- docs/README.md による統一索引作成
- ルート README からの誘導リンク
- Phase 6 運用ドキュメントの整理完了

Snapshot: `reports/snap_p6-5_docs_index.md`

🤖 Generated with [Claude Code](https://claude.ai/code)