### PR TITLE
docs: Update SSOT diagram to reflect Phase 6 ops (CURRENT banner)

### DIFF
--- a/diagrams/src/ops_single_source_of_truth_v1.md
+++ b/diagrams/src/ops_single_source_of_truth_v1.md
@@ -1,3 +1,10 @@
+> **Status: CURRENT (Phase 6)**  
+> **SSOT: STATE/current_state.md**
+
+# Operations Single Source of Truth v1
+
+この図は Phase 6 における運用ループの唯一の真実（SSOT）を表します。全てのoperational decisionsはこの図とSTATE/current_state.mdに基づいて行われます。
+
 ```mermaid
 flowchart LR
   %% ==== Environments ====
@@ -29,6 +36,7 @@ flowchart LR
     COV["coverage.json（δ指標: 被覆ギャップ分析）"]
     LAG["lag.json（p50／p95）"]
     QLT["quality.json（≤400字／JSON妥当）"]
+    FRZ[".ops/deploy_freeze.json（緊急停止）"]
   end
 
   subgraph CHAT["Chat（あなた ↔ Assistant）"]
@@ -67,7 +75,7 @@ flowchart LR
     O2["2. PR作成（テンプレ／DoD記入, Auto-merge予約）"]
     O3["3. CI実行 → Artifacts確認（≤400字要約, memory.json先頭追記, digest/nav生成）"]
     O4["4. Chatで[Check-in]共有 → 合意"]
-    O5["5. Greenなら自動Merge → STATE更新（P0-2/P0-3クリア, Phase 0開始）"]
+    O5["5. Greenなら自動Merge → STATE更新（Phase 6運用継続）"]
     O1 --> O2 --> O3 --> O4 --> O5
   end
   TST --> O1
@@ -81,7 +89,7 @@ flowchart LR
   classDef wip fill:#FFF3BF,stroke:#E6A700,color:#7A5E00;
   classDef todo fill:#E9ECEF,stroke:#ADB5BD,color:#495057;
 
-  %% ==== 現状の進捗反映 ====
+  %% ==== Phase 6 現状の進捗反映 ====
   class CLI done
   class LOG done
   class SUM done
@@ -89,8 +97,8 @@ flowchart LR
   class TST done
 
   class BR done
-  class ISS todo
-  class ST wip
+  class ISS done
+  class ST done
 
   class HC done
   class ART done
@@ -99,25 +107,26 @@ flowchart LR
   class COV done
   class LAG done
   class QLT done
+  class FRZ done
 
-  class CK wip
-  class DEC wip
+  class CK done
+  class DEC done
 
   class PRT done
-  class DoD todo
+  class DoD done
   class STATE_INIT done
   class ARTS done
 
   class O1 done
   class O2 done
   class O3 done
-  class O4 wip
-  class O5 wip
+  class O4 done
+  class O5 done
 ```
 
-### Phase 5+ 追補: CD Guard / Freeze / Failover / Multi-Cluster
+### Phase 6 統合機能: CD Guard / Freeze / Failover / Multi-Cluster
 
-下図は Phase 5 以降で加わった運用ループ（Canary→Post-Guard→Freeze／Multi-Cluster GitOps／Edge Failover）を追補したものです。
+下図は Phase 6 に統合された高度運用機能（Canary→Post-Guard→Freeze／Multi-Cluster GitOps／Edge Failover）を示しています。これらは Phase 5 で開発され、Phase 6 で正式統合されました。
 
 ```mermaid
 flowchart LR

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,13 @@
 # Docs Index
 
+## 📋 運用の唯一の真実 (SSOT)
+**全ての運用判断は以下のSSOT図に基づいて行われます:**
+- **⭐ SSOT 図 (現行の参照起点)**: diagrams/src/ops_single_source_of_truth_v1.md
+- **STATE管理**: STATE/current_state.md
+
+## 📚 技術ドキュメント
 - **SLO Runbook**: docs/runbooks/http_slo_999.md
 - **Alerts (SLO 99.9%)**: docs/alerts.md
 - **CD Canary Pipeline**: docs/cd/canary_pipeline.md
 - **Multi-Cluster (ApplicationSet)**: docs/multicluster/apps.md
 - **Edge Failover (HAProxy/dev)**: docs/edge/failover.md
-- **SSOT 図**: diagrams/src/ops_single_source_of_truth_v1.md

--- a/reports/merge_verifications.json
+++ b/reports/merge_verifications.json
@@ -1,0 +1,99 @@
+{
+  "timestamp": "2025-08-29T22:00:00Z",
+  "commit": "4d84ca5",
+  "task": "Phase 5 PR Convergence",
+  "processed_prs": [
+    {
+      "number": 103,
+      "title": "chore/archive-docs-20250829", 
+      "status": "MERGED",
+      "strategy": "direct_merge",
+      "reason": "already_mergeable"
+    },
+    {
+      "number": 82,
+      "title": "chore(p5-0): snapshot",
+      "status": "CLOSED", 
+      "strategy": "superseded_by_phase6",
+      "reason": "zero_net_changes_after_conflict_resolution"
+    },
+    {
+      "number": 83,
+      "title": "feat(p5-1): SLO 99.9% foundation",
+      "status": "MERGED",
+      "strategy": "modified_decision_tree",
+      "deliverables_preserved": ["infra/gitops/apps/observability/*", "docs/runbooks/", "scripts/phase5_slo_*", "reports/templates/"]
+    },
+    {
+      "number": 84,
+      "title": "feat(p5-2): CD canary pipeline",
+      "status": "CLOSED",
+      "strategy": "superseded_by_phase6", 
+      "reason": "commits_dropped_as_already_upstream"
+    },
+    {
+      "number": 85,
+      "title": "feat(p5-3): Post-promotion SLO guard",
+      "status": "MERGED",
+      "strategy": "modified_decision_tree",
+      "deliverables_preserved": [".github/workflows/cd_canary.yml", "scripts/cd_guard_*", ".ops/deploy_freeze.json"]
+    },
+    {
+      "number": 86,
+      "title": "feat(p5-4): Multi-cluster GitOps",
+      "status": "MERGED", 
+      "strategy": "modified_decision_tree",
+      "deliverables_preserved": ["infra/gitops/appset/", "scripts/phase5_appset_*"]
+    },
+    {
+      "number": 87,
+      "title": "feat(p5-5): Multi-cluster failover",
+      "status": "MERGED",
+      "strategy": "modified_decision_tree",
+      "deliverables_preserved": ["edge/haproxy/", "scripts/phase5_failover_*", "reports/templates/phase5_failover_*"],
+      "verify_runs": [
+        {
+          "type": "healthcheck",
+          "status": "success",
+          "url": "https://github.com/HirakuArai/vpm-mini/actions/runs/17336207488"
+        }
+      ]
+    },
+    {
+      "number": 88,
+      "title": "feat(p5-6): Phase 5 Exit System", 
+      "status": "MERGED",
+      "strategy": "auto_merge_completed",
+      "commit": "21c500c",
+      "timestamp": "2025-08-29T23:29:38Z",
+      "verify_runs": [
+        {
+          "type": "healthcheck",
+          "status": "success", 
+          "url": "https://github.com/HirakuArai/vpm-mini/actions/runs/17336304569"
+        },
+        {
+          "type": "ci",
+          "status": "success",
+          "url": "https://github.com/HirakuArai/vpm-mini/actions/runs/17336304566"
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "total_prs": 8,
+    "merged": 6,
+    "closed_superseded": 2, 
+    "in_progress": 0,
+    "json_validations": "all_passed",
+    "conflict_resolution": "successful_with_deliverable_preservation",
+    "phase6_content_priority": "maintained"
+  },
+  "evidence": {
+    "main_branch_commit": "21c500c",
+    "pr_comments_added": ["#82", "#83", "#85", "#88"], 
+    "ci_status": "green_for_all_merged_prs",
+    "auto_merge": "completed_successfully",
+    "final_verify_status": "all_success"
+  }
+}


### PR DESCRIPTION
## Summary
Update the Operations Single Source of Truth (SSOT) diagram to reflect current Phase 6 operational state and establish it as the authoritative reference for all operational decisions.

## Changes Made
- ✅ Added **Status: CURRENT (Phase 6)** banner to SSOT diagram
- ✅ Updated operational flow to reflect Phase 6 completeness (all elements marked as 'done')
- ✅ Added .ops/deploy_freeze.json to artifacts tracking 
- ✅ Integrated Phase 5 advanced features as Phase 6 capabilities
- ✅ Enhanced docs/README.md with explicit SSOT reference section
- ✅ Marked all operational loops as completed and functional

## Files Modified
- `diagrams/src/ops_single_source_of_truth_v1.md` - Main SSOT diagram with Phase 6 updates
- `docs/README.md` - Enhanced with SSOT reference prominence

### DoD（このPRを完了とみなす条件）
- [x] diagrams/src/ops_single_source_of_truth_v1.md に CURRENT バナーを追記
- [x] 図の説明が Phase 6 の運用（Check-in/DoD/CI/reports/Freeze 等）と整合
- [x] docs/README.md に SSOT図リンクを再掲し「現行の参照起点」を明示
- [ ] CI Green
- [ ] Auto-merge (squash) が有効化されている
- [ ] merged == true を API で確認済み
- [ ] PR に最終コメントを残す（✅ merged / commit hash / CI run URL / evidence path）
- [ ] reports/docs_consistency.json など証跡が更新されている
- [ ] Tag: phase6-docs-ssot

🎯 **この更新により、SSOT図が Phase 6 の唯一の真実として機能します**