### PR TITLE
feat(p6-1): P6-1.A — Secrets登録手前まで準備完了

### DIFF
--- a/.github/workflows/cd_canary_multicluster.yml
+++ b/.github/workflows/cd_canary_multicluster.yml
@@ -47,6 +47,12 @@ jobs:
           echo "skip=false" >> $GITHUB_OUTPUT
         shell: bash
 
+      - name: Require secrets
+        if: steps.freeze.outputs.skip == 'false' && (!secrets.KUBECONFIG_A_BASE64 || !secrets.KUBECONFIG_B_BASE64)
+        run: |
+          echo "::error::Missing KUBECONFIG_A_BASE64 / KUBECONFIG_B_BASE64. Repo Settings > Secrets > Actions で登録してください。"
+          exit 1
+
       - name: Install deps (kubectl/jq)
         if: steps.freeze.outputs.skip == 'false'
         run: |

--- a/infra/k8s/overlays/dev/hello-ksvc.yaml
+++ b/infra/k8s/overlays/dev/hello-ksvc.yaml
@@ -10,6 +10,7 @@ spec:
         autoscaling.knative.dev/minScale: "0"
         autoscaling.knative.dev/maxScale: "50"
         autoscaling.knative.dev/target: "100"
+        # rollout-hash: "<to-be-filled-after-secrets>"
     spec:
       containers:
         - image: gcr.io/knative-samples/helloworld-go

--- a/rbac/knative-rollout.yaml
+++ b/rbac/knative-rollout.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata: { name: cd-runner, namespace: hyper-swarm }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: { name: knative-rollout, namespace: hyper-swarm }
+rules:
+  - apiGroups: ["serving.knative.dev"]
+    resources: ["services"]
+    verbs: ["get","list","watch","patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: { name: knative-rollout, namespace: hyper-swarm }
+subjects:
+  - kind: ServiceAccount
+    name: cd-runner
+    namespace: hyper-swarm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: knative-rollout


### PR DESCRIPTION
P6-1.A — Secrets登録手前までの準備を完了

Auto-merge (squash) 有効化
CI 必須チェック Green（test-and-artifacts, healthcheck）
merged == true を API で確認
PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
必要な証跡（例: reports/*）を更新

## 実装内容

### ✅ RBAC 最小権限設定
- rbac/knative-rollout.yaml 追加
- ServiceAccount: cd-runner (hyper-swarm namespace)
- Role: serving.knative.dev/services への get,list,watch,patch権限のみ
- RoleBinding: cd-runner ↔ knative-rollout

### ✅ Secrets必須チェック追加
- cd_canary_multicluster.yml に validation step 追加
- KUBECONFIG_A_BASE64 / KUBECONFIG_B_BASE64 未設定時に即座にエラー
- GitHub Secrets設定の案内メッセージ付き

### ✅ 自動起動テスト準備
- infra/k8s/overlays/dev/hello-ksvc.yaml にダミー注釈追加
- rollout-hash コメント（実際のテストは後で実行）

## 次ステップ
1. このPRマージ後、GitHub Secrets に kubeconfig 設定
2. hello/** 変更での自動デプロイテスト実行
3. workflow_dispatch での手動テスト実行