### PR TITLE
fix(cd): correct secrets syntax in CD workflow

### DIFF
--- a/.github/workflows/cd_canary_multicluster.yml
+++ b/.github/workflows/cd_canary_multicluster.yml
@@ -48,10 +48,15 @@ jobs:
         shell: bash
 
       - name: Require secrets
-        if: steps.freeze.outputs.skip == 'false' && (!secrets.KUBECONFIG_A_BASE64 || !secrets.KUBECONFIG_B_BASE64)
+        if: steps.freeze.outputs.skip == 'false'
+        env:
+          KUBECONFIG_A_BASE64: ${{ secrets.KUBECONFIG_A_BASE64 }}
+          KUBECONFIG_B_BASE64: ${{ secrets.KUBECONFIG_B_BASE64 }}
         run: |
-          echo "::error::Missing KUBECONFIG_A_BASE64 / KUBECONFIG_B_BASE64. Repo Settings > Secrets > Actions で登録してください。"
-          exit 1
+          if [ -z "$KUBECONFIG_A_BASE64" ] || [ -z "$KUBECONFIG_B_BASE64" ]; then
+            echo "::error::Missing KUBECONFIG_A_BASE64 / KUBECONFIG_B_BASE64. Repo Settings > Secrets > Actions で登録してください。"
+            exit 1
+          fi
 
       - name: Install deps (kubectl/jq)
         if: steps.freeze.outputs.skip == 'false'


### PR DESCRIPTION
Fix CD workflow secrets syntax error

Auto-merge (squash) 有効化
CI 必須チェック Green（test-and-artifacts, healthcheck）
merged == true を API で確認
PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
必要な証跡（例: reports/*）を更新

Fixes GitHub Actions syntax error in secrets reference