### PR TITLE
chore: SSOT正規化（Phase 0/2 実証を前提に再整列）+ 決定ログ追加

### DIFF
--- a/.ops/README.freeze.md
+++ b/.ops/README.freeze.md
@@ -1,0 +1,9 @@
+# deploy_freeze 運用ノート
+- 目的：本番系CDの暴発を防ぎ、**READYな計測対象が揃うまで**観測ライン拡張(#125)を停止する。
+- 現状：`.ops/deploy_freeze.json` = `true`（解除条件は下記）
+
+## 解除条件
+1. Phase 0 サニティ完了（5ロール一周・`make test` Green・証跡保存）
+2. Phase 2 Kickoff完了（`hello-ksvc` READY=True / `curl` HTTP 200・証跡保存）
+
+※ 上記**両方**を `reports/` の証跡で確認後、freeze を解除して #125 を再開する。

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # vpm-mini
 
+**context_header:** repo=vpm-mini / branch=main / phase=Phase 2
+
 ## Phase 6 (Current)
 
 - Phase 5 完了: `phase5-complete`（GitOps / Canary / Guard / Failover / 800 RPS）

--- a/STATE/current_state.md
+++ b/STATE/current_state.md
@@ -1,23 +1,47 @@
-# この文書の役割
-本プロジェクトでは、事象目的空間における **現在地（C）**、**ゴール（G）**、および **δ（差分）** を常に把握し、次アクションを明確化する。
+# === State Declaration (Single Source of Truth) ===
+active_repo: vpm-mini
+active_branch: main
+phase: Phase 2   # Phase 1 完了 → 小規模 Swarm Kickoffへ
+context_header: "repo=vpm-mini / branch=main / phase=Phase 2"
+short_goal: "Phase 2 Kickoff（kind + Knative 足場構築）"
+exit_criteria:
+  - "P2-1 GREEN: kind + Knative (v1.18) 足場構築スクリプトが動作"
+  - "P2-2 GREEN: Hello KService デプロイ成功（kubectl get ksvc hello → READY=True / curl→HTTP 200）"
+updated_at: 2025-09-02T09:00:00+09:00
 
 ---
 
-## 状態宣言 (SSOT)
-```yaml
-active_repo: vpm-mini
-active_branch: main
-phase: Phase 6   # Global Resilience & Scale
-context_header: "repo=vpm-mini / branch=main / phase=Phase 4"
-short_goal: "マルチクラスタのグローバル配信 + 30日連続 SLO 99.9%"
-exit_criteria:
-  - GSLB/Edge で multi-cluster ルーティング（自動フェイルオーバー）
-  - GitOps 完全自動（PR→Canary→昇格→Post-Guard）を multi-cluster に展開
-  - 30日連続 SLO 99.9%（アラート/Runbook/自動回復の運用実績）
+## この文書の役割
+本プロジェクトは、事象目的空間における **現在地（C）**、**ゴール（G）**、差分 **δ** を常に明示し、次の一手を機械的に判断できるようにする。ここでは **唯一の前提（SSOT）** を宣言する。
 
-## Phase 6 進捗状況
-- **P6-1**: Multi-Cluster Canary Deploy **[GREEN]** ✅
-  - CD Canary Multi-Cluster workflow 実装完了
-  - RBAC 最小権限設定完了
-  - Secrets validation & Freeze機能検証完了
-  - Auto-startup test & [FREEZE] skip 動作確認済み
+## プロジェクト最終目的
+**Hyper-Swarm / VPM** を構築し、複数AIエージェントの連携により **常時自己進化型の開発運用基盤** を確立する。
+
+## フェーズ構成と現在地
+- **Phase 0**：ローカル venv で 5ロール（対話→要約→プラン→エコー）一周の証跡化
+- **Phase 1**：Compose + 監視土台（完了）
+- **Phase 2（←現在地）**：kind + Knative（v1.18）足場 → Hello KService `READY=True / HTTP 200` の証跡化
+- 以降：サービス移植・Autoscale・観測ラインのK8s移行
+
+## 現在地（C）
+- Phase 1 までの環境は main で安定
+- #128 により **Evidence Check（PR本文↔差分の不整合検知）** 導入済み
+- `.ops/deploy_freeze.json` は **true 維持**（不要なCDを抑止）
+- **欠落**：Phase 0 サニティ（5ロール一周の実行証跡）／ Phase 2 `hello-ksvc` READY 証跡
+
+## ゴール（G）— Phase 2 Kickoff 達成
+- **P2-1**: `scripts/p2_bootstrap_kind_knative.sh` で kind + Knative v1.18 を冪等構築
+- **P2-2**: `infra/k8s/overlays/dev/hello-ksvc.yaml` を適用し  
+  `kubectl get ksvc hello` → `READY=True`、`curl` 応答 → `HTTP 200` の証跡を `reports/` に保存
+
+## 差分（δ：方向と距離）
+- 距離：Phase 0 サニティ + Phase 2 READY 証跡が未充足
+- 方向：**器（CI/観測）より中身（実行対象とAI駆動サイクル）を先に**。P2-1 → P2-2 → #125 再開
+
+## 優先タスク（直近の順序）
+1. **Phase 0 サニティ**：ローカルで 5ロール一周 → `make test` Green → ログ/JSON証跡コミット
+2. **P2-1 / P2-2**：kind + Knative 足場構築 → `hello-ksvc` READY & HTTP 200 証跡化
+3. **#125 観測ライン拡張**：READY 達成後に Pushgateway / Grafana をKnativeへ
+
+## 決定（2025-09-02）
+- 「本質的処理（AI中心の5ロール循環・READYなKService）」が未実証であったため、**Phase 0 / 2 へ立ち戻って証跡を先に揃える**。Freeze は READY 証跡が揃ったタイミングで解除し、#125 を進める。

--- a/reports/2025-09-02_decision_phase0_reset.md
+++ b/reports/2025-09-02_decision_phase0_reset.md
@@ -1,0 +1,29 @@
+# Decision: 本質未実証の是正（Phase 0/2 へリセット）
+Date: 2025-09-02
+Refs: #125（観測ライン拡張）, #128（Evidence Check）
+
+## 背景
+- 表層のCI/観測は進んでいたが、**AIを中心に据えた本質的処理**（5ロール一周・READYなKService）が未実証。
+
+## 決定
+- SSOT を「Phase 2 Kickoff直前」に正規化し、**P2-1 → P2-2 を最優先で達成**。
+- `.ops/deploy_freeze.json` は READY 証跡が揃うまで **true 維持**。#125 はその後に再開。
+
+## 具体アクション（証跡）
+1) Phase 0 サニティ  
+- `playground.py`：対話→要約→プラン→エコーの一周  
+- `make test` Green（JSON 妥当・要約圧縮・ROUGE-L基準）→ ログ/検証を `reports/` に保存
+
+2) Phase 2 Kickoff  
+- `scripts/p2_bootstrap_kind_knative.sh`（冪等）  
+- `infra/k8s/overlays/dev/hello-ksvc.yaml` 適用  
+- 証跡：  
+  - `kubectl get ksvc hello` → `READY=True`  
+  - `curl -sS http://<local-ingress>` → `HTTP 200`  
+  - 以上を `reports/ksvc_hello_proof_YYYYMMDD.md` に添付
+
+## DoD
+- [ ] `STATE/current_state.md` / 本ドキュメントが main に存在  
+- [ ] Phase 0 サニティのテスト結果を `reports/` に保存  
+- [ ] `hello-ksvc` の READY / 200 の証跡を `reports/` に保存  
+- [ ] `.ops/README.freeze.md` に Freeze 方針と解除条件を明記


### PR DESCRIPTION
## 目的
- 見かけのPhase5進行を是正し、SSOTを **Phase 2 Kickoff直前** へ正規化。
- 「本質的処理（5ロール一周 / READYなKService）」未実証を明文化し、先に証跡を揃える。

## 変更
- STATE/current_state.md：C/G/δ、優先タスク、決定の明記
- reports/2025-09-02_decision_phase0_reset.md：理由とDoDの固定
- README.md：context_header を Phase 2 に更新
- .ops/README.freeze.md：freeze の理由と解除条件

## 方針
- `.ops/deploy_freeze.json` は **true維持**。解除は「Phase 0 サニティ + Phase 2 READY 証跡」完了後。

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

<!-- 上記5行は削除/改変しないでください -->

## Evidence (for this PR)
```evidence
STATE/current_state.md
reports/2025-09-02_decision_phase0_reset.md
README.md
.ops/README.freeze.md
```