### PR TITLE
feat(p3-2.1): SPIRE minimal install + evidence

### DIFF
--- a/infra/spire/quickstart_source.txt
+++ b/infra/spire/quickstart_source.txt
@@ -1,0 +1,1 @@
+https://raw.githubusercontent.com/spiffe/spire/main/support/k8s/quickstart/spire.yaml

--- a/infra/spire/spire-agent.yaml
+++ b/infra/spire/spire-agent.yaml
@@ -1,0 +1,130 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spire-agent
+  namespace: spire-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: spire-agent
+rules:
+- apiGroups: [""]
+  resources: ["pods", "nodes", "nodes/proxy"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: spire-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: spire-agent
+subjects:
+- kind: ServiceAccount
+  name: spire-agent
+  namespace: spire-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spire-agent
+  namespace: spire-system
+data:
+  agent.conf: |
+    agent {
+      data_dir = "/run/spire"
+      log_level = "DEBUG"
+      server_address = "spire-server"
+      server_port = "8081"
+      trust_domain = "example.org"
+      insecure_bootstrap = true
+    }
+    plugins {
+      NodeAttestor "k8s_psat" {
+        plugin_data {
+          cluster = "demo-cluster"
+          token_path = "/run/secrets/tokens/spire-agent"
+        }
+      }
+      KeyManager "memory" {
+        plugin_data {}
+      }
+      WorkloadAttestor "k8s" {
+        plugin_data {
+          skip_kubelet_verification = true
+        }
+      }
+    }
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: spire-agent
+  namespace: spire-system
+spec:
+  selector:
+    matchLabels:
+      app: spire-agent
+  template:
+    metadata:
+      labels:
+        app: spire-agent
+    spec:
+      serviceAccountName: spire-agent
+      hostPID: true
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: spire-agent
+        image: ghcr.io/spiffe/spire-agent:1.9.0
+        args: ["-config", "/run/spire/config/agent.conf"]
+        volumeMounts:
+        - name: spire-config
+          mountPath: /run/spire/config
+          readOnly: true
+        - name: spire-bundle
+          mountPath: /run/spire/bundle
+        - name: spire-agent-socket
+          mountPath: /run/spire/sockets
+        - name: spire-token
+          mountPath: /run/secrets/tokens
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 60
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: spire-config
+        configMap:
+          name: spire-agent
+      - name: spire-bundle
+        configMap:
+          name: spire-bundle
+          optional: true
+      - name: spire-agent-socket
+        hostPath:
+          path: /run/spire/sockets
+          type: DirectoryOrCreate
+      - name: spire-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: spire-agent
+              expirationSeconds: 7200
+              audience: spire-server

--- a/infra/spire/spire-namespace.yaml
+++ b/infra/spire/spire-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spire-system

--- a/infra/spire/spire-server.yaml
+++ b/infra/spire/spire-server.yaml
@@ -1,0 +1,157 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spire-server
+  namespace: spire-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: spire-server
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "pods", "configmaps"]
+  verbs: ["get", "list", "watch", "patch", "update"]
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: spire-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: spire-server
+subjects:
+- kind: ServiceAccount
+  name: spire-server
+  namespace: spire-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spire-server
+  namespace: spire-system
+data:
+  server.conf: |
+    server {
+      bind_address = "0.0.0.0"
+      bind_port = "8081"
+      trust_domain = "example.org"
+      data_dir = "/run/spire/data"
+      log_level = "DEBUG"
+      ca_subject = {
+        country = ["US"],
+        organization = ["SPIFFE"],
+        common_name = "",
+      }
+      ca_ttl = "12h"
+      default_x509_svid_ttl = "1h"
+    }
+    plugins {
+      DataStore "sql" {
+        plugin_data {
+          database_type = "sqlite3"
+          connection_string = "/run/spire/data/datastore.sqlite3"
+        }
+      }
+      NodeAttestor "k8s_psat" {
+        plugin_data {
+          clusters = {
+            "demo-cluster" = {
+              service_account_allow_list = ["spire-system:spire-agent"]
+            }
+          }
+        }
+      }
+      KeyManager "memory" {
+        plugin_data {}
+      }
+      Notifier "k8sbundle" {
+        plugin_data {
+          namespace = "spire-system"
+        }
+      }
+    }
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: spire-server
+  namespace: spire-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spire-server
+  serviceName: spire-server
+  template:
+    metadata:
+      labels:
+        app: spire-server
+    spec:
+      serviceAccountName: spire-server
+      containers:
+      - name: spire-server
+        image: ghcr.io/spiffe/spire-server:1.9.0
+        args: ["-config", "/run/spire/config/server.conf"]
+        ports:
+        - containerPort: 8081
+          name: grpc
+        - containerPort: 8080
+          name: healthz
+        volumeMounts:
+        - name: spire-config
+          mountPath: /run/spire/config
+          readOnly: true
+        - name: spire-data
+          mountPath: /run/spire/data
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: 8080
+          failureThreshold: 2
+          initialDelaySeconds: 15
+          periodSeconds: 60
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: spire-config
+        configMap:
+          name: spire-server
+  volumeClaimTemplates:
+  - metadata:
+      name: spire-data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: spire-server
+  namespace: spire-system
+spec:
+  type: ClusterIP
+  selector:
+    app: spire-server
+  ports:
+  - name: grpc
+    port: 8081
+    targetPort: 8081

--- a/reports/p3_2_1_spire_min_20250907_044931.md
+++ b/reports/p3_2_1_spire_min_20250907_044931.md
@@ -1,0 +1,89 @@
+# P3-2.1 SPIRE Minimal Install Evidence (20250907_044931)
+
+## Deployment Status
+```
+NAME                    READY   STATUS    RESTARTS        AGE
+pod/spire-agent-jmqj8   1/1     Running   0               43s
+pod/spire-server-0      1/1     Running   3 (2m55s ago)   3m16s
+
+NAME                   TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)    AGE
+service/spire-server   ClusterIP   10.96.54.12   <none>        8081/TCP   42m
+
+NAME                         DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
+daemonset.apps/spire-agent   1         1         1       1            1           <none>          42m
+
+NAME                            READY   AGE
+statefulset.apps/spire-server   1/1     42m
+```
+
+## Pods
+```
+NAME                READY   STATUS    RESTARTS        AGE     IP           NODE          NOMINATED NODE   READINESS GATES
+spire-agent-jmqj8   1/1     Running   0               43s     172.18.0.6   kind-worker   <none>           <none>
+spire-server-0      1/1     Running   3 (2m55s ago)   3m16s   10.244.0.9   kind-worker   <none>           <none>
+```
+
+## Server logs (last 30 lines)
+```
+time="2025-09-06T19:47:05Z" level=warning msg="JWT key slot unusable" error="no key manager key" issued_at="2025-09-06 19:46:18 +0000 UTC" local_authority_id=bV6AexHguN9eXaoz0EHW1Rq0jayPcfzI slot=A status=ACTIVE subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=warning msg="JWT key slot unusable" error="no key manager key" issued_at="2025-09-06 19:46:18 +0000 UTC" local_authority_id=H0EhKZE1A494ePNZPlWcqfinYgcfNqC3 slot=A status=ACTIVE subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=warning msg="JWT key slot unusable" error="no key manager key" issued_at="2025-09-06 19:45:51 +0000 UTC" local_authority_id=HyCvohkIaNugRHWGwAvNlTHzzdmeS5EU slot=A status=ACTIVE subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=warning msg="JWT key slot unusable" error="no key manager key" issued_at="2025-09-06 19:45:09 +0000 UTC" local_authority_id=RrCEEo6OG18n2s8x52bnr3JHtM2tS7QW slot=A status=ACTIVE subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=warning msg="JWT key slot unusable" error="no key manager key" issued_at="2025-09-06 19:44:42 +0000 UTC" local_authority_id=46zRxp0ZaeJgWUC2nLKtJO1skj1Zo5iQ slot=A status=ACTIVE subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=warning msg="JWT key slot unusable" error="no key manager key" issued_at="2025-09-06 19:44:23 +0000 UTC" local_authority_id=LTuFcF7sm6NwEQAvzx5r0hQmw5ASwEe4 slot=A status=ACTIVE subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=warning msg="JWT key slot unusable" error="no key manager key" issued_at="2025-09-06 19:44:22 +0000 UTC" local_authority_id=K5NbVHLdSdIpcEBnNrzCkYUaNsdV6Rob slot=A status=ACTIVE subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=debug msg="Preparing X509 CA" slot=A subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=info msg="Creating a new CA journal entry" subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=debug msg="Successfully stored CA journal entry in datastore" ca_journal_id=9 local_authority_id= subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=info msg="X509 CA prepared" expiration="2025-09-07 07:47:05 +0000 UTC" issued_at="2025-09-06 19:47:05.150302011 +0000 UTC" local_authority_id=b320caa2a6cf9b1b064c3138228f5feba1a553ae self_signed=true slot=A subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=info msg="X509 CA activated" expiration="2025-09-07 07:47:05 +0000 UTC" issued_at="2025-09-06 19:47:05.150302011 +0000 UTC" local_authority_id=b320caa2a6cf9b1b064c3138228f5feba1a553ae slot=A subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=debug msg="Successfully stored CA journal entry in datastore" ca_journal_id=9 local_authority_id=b320caa2a6cf9b1b064c3138228f5feba1a553ae subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=debug msg="Successfully rotated X.509 CA" subsystem_name=ca_manager trust_domain_id="spiffe://example.org" ttl=43199.846009781
+time="2025-09-06T19:47:05Z" level=debug msg="Preparing JWT key" slot=A subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=debug msg="Successfully stored CA journal entry in datastore" ca_journal_id=9 local_authority_id=b320caa2a6cf9b1b064c3138228f5feba1a553ae subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=info msg="JWT key prepared" expiration="2025-09-07 07:47:05.154008386 +0000 UTC" issued_at="2025-09-06 19:47:05.154008386 +0000 UTC" local_authority_id=Ow0F65oUccU0hNgzgnSVZPeGcHsuatYz slot=A subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=info msg="JWT key activated" expiration="2025-09-07 07:47:05.154008386 +0000 UTC" issued_at="2025-09-06 19:47:05.154008386 +0000 UTC" local_authority_id=Ow0F65oUccU0hNgzgnSVZPeGcHsuatYz slot=A subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=debug msg="Successfully stored CA journal entry in datastore" ca_journal_id=9 local_authority_id=b320caa2a6cf9b1b064c3138228f5feba1a553ae subsystem_name=ca_manager
+time="2025-09-06T19:47:05Z" level=debug msg="Rotating server SVID" subsystem_name=svid_rotator
+time="2025-09-06T19:47:05Z" level=debug msg="Signed X509 SVID" expiration="2025-09-06T20:47:05Z" spiffe_id="spiffe://example.org/spire/server" subsystem_name=svid_rotator
+time="2025-09-06T19:47:05Z" level=info msg="Building in-memory entry cache" subsystem_name=endpoints
+time="2025-09-06T19:47:05Z" level=info msg="Completed building in-memory entry cache" subsystem_name=endpoints
+time="2025-09-06T19:47:05Z" level=debug msg="Initializing API endpoints" subsystem_name=endpoints
+time="2025-09-06T19:47:05Z" level=info msg="Starting Server APIs" address=/tmp/spire-server/private/api.sock network=unix subsystem_name=endpoints
+time="2025-09-06T19:47:05Z" level=info msg="Starting Server APIs" address="[::]:8081" network=tcp subsystem_name=endpoints
+time="2025-09-06T19:47:06Z" level=debug msg="Initializing health checkers" subsystem_name=health
+time="2025-09-06T19:47:06Z" level=info msg="Serving health checks" address="0.0.0.0:8080" subsystem_name=health
+time="2025-09-06T19:47:06Z" level=debug msg="Notifier handled event" event="bundle loaded" notifier=k8sbundle subsystem_name=ca_manager
+time="2025-09-06T19:48:51Z" level=info msg="Agent attestation request completed" address="10.244.0.1:2715" agent_id="spiffe://example.org/spire/agent/k8s_psat/demo-cluster/d4b00d3d-ca8e-4acd-a70f-c7af8c5c84d8" authorized_as=nobody authorized_via= caller_addr="10.244.0.1:2715" method=AttestAgent node_attestor_type=k8s_psat request_id=9fb6fe71-d71c-42a4-8c12-f8f2be1d9f55 service=agent.v1.Agent subsystem_name=api
+```
+
+## Agent logs (last 30 lines)
+```
+time="2025-09-06T19:48:50Z" level=info msg="Creating spire agent UDS directory" dir=/tmp/spire-agent/public
+time="2025-09-06T19:48:50Z" level=warning msg="Current umask 0022 is too permissive; setting umask 0027"
+time="2025-09-06T19:48:50Z" level=info msg="Starting agent with data directory: \"/run/spire\""
+time="2025-09-06T19:48:50Z" level=info msg="Plugin loaded" external=false plugin_name=k8s_psat plugin_type=NodeAttestor subsystem_name=catalog
+time="2025-09-06T19:48:50Z" level=info msg="Plugin loaded" external=false plugin_name=memory plugin_type=KeyManager subsystem_name=catalog
+time="2025-09-06T19:48:50Z" level=info msg="Plugin loaded" external=false plugin_name=k8s plugin_type=WorkloadAttestor subsystem_name=catalog
+time="2025-09-06T19:48:50Z" level=info msg="Bundle is not found" subsystem_name=attestor
+time="2025-09-06T19:48:50Z" level=debug msg="No pre-existing agent SVID found. Will perform node attestation" subsystem_name=attestor
+time="2025-09-06T19:48:50Z" level=info msg="SVID is not found. Starting node attestation" subsystem_name=attestor
+time="2025-09-06T19:48:50Z" level=warning msg="Insecure bootstrap enabled; skipping server certificate verification" subsystem_name=attestor
+time="2025-09-06T19:48:51Z" level=info msg="Node attestation was successful" rettestable=true spiffe_id="spiffe://example.org/spire/agent/k8s_psat/demo-cluster/d4b00d3d-ca8e-4acd-a70f-c7af8c5c84d8" subsystem_name=attestor
+time="2025-09-06T19:48:51Z" level=debug msg="Bundle added" subsystem_name=svid_store_cache trust_domain_id=example.org
+time="2025-09-06T19:48:51Z" level=info msg="Starting Workload and SDS APIs" address=/tmp/spire-agent/public/api.sock network=unix subsystem_name=endpoints
+time="2025-09-06T19:48:51Z" level=debug msg="Initializing health checkers" subsystem_name=health
+time="2025-09-06T19:48:51Z" level=info msg="Serving health checks" address="0.0.0.0:8080" subsystem_name=health
+```
+
+## Manifest files created
+```
+total 40
+drwxr-xr-x@ 7 hiraku  staff   224  9  7 04:44 .
+drwxr-xr-x@ 8 hiraku  staff   256  9  7 04:00 ..
+-rw-r--r--@ 1 hiraku  staff    86  9  7 04:00 quickstart_source.txt
+-rw-r--r--@ 1 hiraku  staff  3033  9  7 04:48 spire-agent.yaml
+-rw-r--r--@ 1 hiraku  staff    62  9  7 04:04 spire-namespace.yaml
+-rw-r--r--@ 1 hiraku  staff  1195  9  7 04:44 spire-server-fixed.yaml
+-rw-r--r--@ 1 hiraku  staff  3458  9  7 04:44 spire-server.yaml
+```


### PR DESCRIPTION
## Summary
- SPIRE（server/agent）を最小導入し、稼働を確認
- 証跡: `reports/p3_2_1_spire_min_*.md`（Pod一覧・ログ抜粋）

## DoD（全角）
（　）`spire-system` で server/agent が稼働（rollout 完了）
（　）証跡 `reports/p3_2_1_spire_min_*.md` を保存
（　）Auto-merge（squash）で main に統合

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新