### PR TITLE
feat(P1-3): Grafana K8s datasource + p50 panel switch

### DIFF
--- a/grafana/provisioning/dashboards/phase1_kpi.json
+++ b/grafana/provisioning/dashboards/phase1_kpi.json
@@ -26,7 +26,11 @@
       "title": "p50 latency",
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum by (le)(rate(prometheus_http_request_duration_seconds_bucket[5m])))"
+          "expr": "histogram_quantile(0.5, sum by (le)(rate(prometheus_http_request_duration_seconds_bucket[5m])))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom-k8s"
+          }
         }
       ],
       "gridPos": {
@@ -34,6 +38,10 @@
         "y": 0,
         "w": 12,
         "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom-k8s"
       }
     },
     {

--- a/grafana/provisioning/datasources/ds.yml
+++ b/grafana/provisioning/datasources/ds.yml
@@ -5,3 +5,12 @@ datasources:
     access: proxy
     url: http://prometheus:9090
     isDefault: true
+
+  - name: PrometheusK8s
+    uid: prom-k8s
+    type: prometheus
+    access: proxy
+    url: http://prometheus.monitoring.svc:9090
+    isDefault: false
+    jsonData:
+      timeInterval: 5s

--- a/reports/p1_grafana_ds_k8s_20250907_121143.md
+++ b/reports/p1_grafana_ds_k8s_20250907_121143.md
@@ -1,0 +1,14 @@
+# P1-3 Grafana datasource for K8s + p50 panel switch (20250907_121143)
+
+## Datasource
+- file: grafana/provisioning/datasources/ds.yml
+- added:
+  - name: PrometheusK8s
+  - uid: prom-k8s
+  - url: http://prometheus.monitoring.svc:9090
+  - isDefault: false
+
+## Dashboard
+- file: grafana/provisioning/dashboards/phase1_kpi.json
+- panel: "p50 latency"
+- datasource: { "type": "prometheus", "uid": "prom-k8s" }


### PR DESCRIPTION
## Summary
- Grafana datasource 追加:
  - name: **PrometheusK8s**, uid: **prom-k8s**, url: `http://prometheus.monitoring.svc:9090`
- ダッシュボード `phase1_kpi.json` の **p50 latency** パネルを `prom-k8s` に切替

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新