### PR TITLE
docs(P1-4): JSON error metric probe report

### DIFF
--- a/reports/p1_json_error_metric_probe_20250907_131701.md
+++ b/reports/p1_json_error_metric_probe_20250907_131701.md
@@ -1,0 +1,16 @@
+# P1-4 JSON Error Metric Probe (20250907_131701)
+
+## *_total candidates (error numerator)
+- json_invalid_total                                           : 0
+- json_error_total                                             : 0
+- http_requests_total{status=~"5.."}                           : 0
+- http_server_requests_seconds_count{status=~"5.."}            : 0
+- requests_total{code=~"5.."}                                  : 0
+
+## *_total candidates (all requests denominator)
+- requests_total                                               : 0
+- http_requests_total                                          : 0
+- http_server_requests_seconds_count                           : 0
+
+## Note
+- 件数>0 のものが候補です。label（status/code/route/instance等）によって式を最適化します。


### PR DESCRIPTION
## Summary
- Prometheus に存在する JSONエラー率用メトリクス候補（分子/分母）を自動探索し、レポート化
- ファイル: `reports/p1_json_error_metric_probe_*.md`

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green (test-and-artifacts, healthcheck)
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡 (例: reports/*) を更新
## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green (test-and-artifacts, healthcheck)
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡 (例: reports/*) を更新

