### PR TITLE
feat(P1-6): JSON error traffic & auto-switch

### DIFF
--- a/reports/p1_6_json_error_traffic_20250908_054730.md
+++ b/reports/p1_6_json_error_traffic_20250908_054730.md
@@ -1,0 +1,10 @@
+# P1-6 JSON error traffic & switch (20250908_054730)
+- ksvc URL : http://hello-ai.hyper-swarm.127.0.0.1.sslip.io
+- series(request_count)                     : 0
+- series(request_count{response_code=~"5.."}) : 0
+- expr (applied to dashboard):
+```
+vector(0)
+```
+- mode: placeholder(still no request_count)
+- dashboard: grafana/provisioning/dashboards/phase1_kpi.json


### PR DESCRIPTION
## Summary
- hello-ai に軽負荷トラフィックを送信し、\`request_count\` を出現させて JSON error rate を実式へ自動切替（未出現時は 0 維持）
- Evidence: \`reports/p1_6_json_error_traffic_*.md\`

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green (test-and-artifacts, healthcheck)
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡 (例: reports/*) を更新
