### PR TITLE
chore(state): fix ROUGE metric name

### DIFF
--- a/reports/p1_kpi_green_state_update_20250908_083206.md
+++ b/reports/p1_kpi_green_state_update_20250908_083206.md
@@ -7,6 +7,6 @@ histogram_quantile(0.5, sum by (le)(rate(prometheus_http_request_duration_second
 sum(rate(revision_app_request_count{response_code_class="5xx"}[5m])) / sum(rate(revision_app_request_count[5m]))
 
 - ROUGE-L:
-vmp_rouge_l_score
+vpm_rouge_l_score
 
 - datasource: prom-k8s (http://prometheus.monitoring.svc:9090)


### PR DESCRIPTION
## Summary
Fix typo: vmp_rouge_l_score → vpm_rouge_l_score in evidence report

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green (test-and-artifacts, healthcheck)
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡 (例: reports/*) を更新
