### PR TITLE
feat(p3-3): chaos pod-kill (minimal) + evidence

### DIFF
--- a/reports/p3_3_chaos_podkill_20250908_090536.md
+++ b/reports/p3_3_chaos_podkill_20250908_090536.md
@@ -1,0 +1,18 @@
+# P3-3 Chaos (pod-kill) minimal — 20250908_090536
+
+## Before
+- ksvc Ready: True
+- pods:
+pod/hello-ai-00001-deployment-786b9dc8b5-8hbq8
+
+## Action
+- deleted pod: hello-ai-00001-deployment-786b9dc8b5-8hbq8
+
+## After
+- ksvc Ready: True
+- pods:
+pod/hello-ai-00001-deployment-786b9dc8b5-m5mhz
+
+## Smoke
+- traffic result: ok
+- p50(latest 5m): 0.05


### PR DESCRIPTION
## Summary
- hello-ai の代表Podを kill → Knative の自動復旧（Ready=True）を確認
- 軽トラフィック＆p50取得で稼働性を確認
- Evidence: `reports/p3_3_chaos_podkill_*.md`

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green (test-and-artifacts, healthcheck)
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡 (例: reports/*) を更新
