### PR TITLE
docs(state): P3-3 pod-kill GREEN

### DIFF
--- a/STATE/current_state.md
+++ b/STATE/current_state.md
@@ -100,3 +100,4 @@ updated_at: 2025-09-02T09:00:00+09:00
 - P3-2.4 PROV 決定ログ（拡張） ✅（reports/prov_p3_2_4_*.jsonld 生成・証跡あり） — 2025-09-07
 - P1-3 Grafana K8s datasource ✅（prom-k8s 追加・p50 panel 連携・証跡あり） — 2025-09-07
 - P1 KPI 基盤 ✅（p50=Prometheus実配線、JSON error rate=revision_app_request_count 実配線、ROUGE-L=vpm_rouge_l_score） — 2025-09-08
+- P3-3 Chaos（pod-kill最小） ✅（Ready=True継続／p50≈0.05s／証跡あり） — 2025-09-08

--- a/reports/p3_3_podkill_state_update_20250908_092244.md
+++ b/reports/p3_3_podkill_state_update_20250908_092244.md
@@ -1,0 +1,4 @@
+# P3-3 pod-kill GREEN evidence
+- time: 20250908_092244 JST
+- p50≈0.05s
+- source: reports/p3_3_chaos_podkill_20250908_090536.md


### PR DESCRIPTION
## Summary
- P3-3（Chaos: pod-kill 最小）を GREEN として記録
  - Knative 自動復旧（Ready=True）を確認
  - p50(latest 5m) ≈ 0.05s
  - Evidence: reports/p3_3_chaos_podkill_*.md

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新