### PR TITLE
fix: DoD Autofix workflow syntax

### DIFF
--- a/.github/workflows/dod-autofix.yml
+++ b/.github/workflows/dod-autofix.yml
@@ -1,5 +1,5 @@
 name: DoD Autofix
-true:
+on:
   pull_request:
     types:
     - opened


### PR DESCRIPTION
## Summary
- Fix YAML syntax error in DoD Autofix workflow
- Changed `true:` to `on:` to properly define workflow triggers

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

