### PR TITLE
feat(p4-2c): Monitoring をGitOps配下へ（プレースホルダー）

### DIFF
--- a/infra/argocd/apps/monitoring-app.yaml
+++ b/infra/argocd/apps/monitoring-app.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vpm-mini-monitoring
+  namespace: argocd
+spec:
+  project: vpm-mini-dev
+  source:
+    repoURL: https://github.com/HirakuArai/vpm-mini.git
+    targetRevision: main
+    path: infra/k8s/overlays/dev/monitoring
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/infra/k8s/overlays/dev/monitoring/README.md
+++ b/infra/k8s/overlays/dev/monitoring/README.md
@@ -1,0 +1,2 @@
+# monitoring (placeholder)
+# TODO: add manifests (e.g., kube-state-metrics, node-exporter, Grafana) or Helm integration.

--- a/reports/p4_2c_monitoring_20250909_155441.md
+++ b/reports/p4_2c_monitoring_20250909_155441.md
@@ -1,0 +1,22 @@
+# P4-2C Monitoring App Evidence (20250909_155441)
+
+## Apply monitoring app
+
+
+```bash
+kubectl -n argocd apply -f infra/argocd/apps/monitoring-app.yaml
+```
+
+  application.argoproj.io/vpm-mini-monitoring created
+
+## Argo apps
+
+
+```bash
+kubectl -n argocd get applications -o wide
+```
+
+  NAME                  SYNC STATUS   HEALTH STATUS   REVISION                                   PROJECT
+  vpm-mini-hello-ai     OutOfSync     Healthy         73533ba66a502a0d01a3129b4ae834ed07cda11a   vpm-mini-dev
+  vpm-mini-monitoring                                                                            vpm-mini-dev
+  vpm-mini-root         Unknown       Unknown                                                    vpm-mini-dev

--- a/scripts/p4_2c_monitoring_apply.sh
+++ b/scripts/p4_2c_monitoring_apply.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TS="$(date +%Y%m%d_%H%M%S)"
+R="reports/p4_2c_monitoring_${TS}.md"
+echo "# P4-2C Monitoring App Evidence (${TS})" | tee "$R"
+sec(){ echo -e "\n## $1\n" | tee -a "$R"; }
+run(){ echo -e "\n\`\`\`bash\n$*\n\`\`\`\n" | tee -a "$R"; (eval "$@" 2>&1 || true) | sed 's/^/  /' | tee -a "$R"; }
+sec "Apply monitoring app"
+run kubectl -n argocd apply -f infra/argocd/apps/monitoring-app.yaml
+sec "Argo apps"
+run kubectl -n argocd get applications -o wide


### PR DESCRIPTION
## Summary
- Application: vpm-mini-monitoring
- Evidence: reports/p4_2c_monitoring_20250909_155441.md
- Placeholder monitoring app registered under GitOps management
- Creates monitoring namespace with auto-sync enabled

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/p4_2c_monitoring_20250909_155441.md

