### PR TITLE
fix(ghcr): lowercase owner (OCI rule) for GHCR tags + updater annotations

### DIFF
--- a/.github/workflows/build_push_hello_ai.yml
+++ b/.github/workflows/build_push_hello_ai.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      HELLO_CONTEXT: services/hello-ai
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
@@ -22,11 +24,17 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build & Push
+      - name: Derive lowercase owner
+        id: who
+        shell: bash
         run: |
-          IMAGE=ghcr.io/HirakuArai/hello-ai:${{ github.event.inputs.tag }}
-          docker build -t $IMAGE ./services/hello-ai
-          docker push $IMAGE
+          echo "owner_lc=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_OUTPUT
+      - name: Build & Push
+        shell: bash
+        run: |
+          IMAGE=ghcr.io/${{ steps.who.outputs.owner_lc }}/hello-ai:${{ github.event.inputs.tag }}
+          echo "IMAGE=$IMAGE"
+          docker buildx build --progress=plain -t "$IMAGE" -f "$HELLO_CONTEXT/Dockerfile" "$HELLO_CONTEXT" --push
       - name: Evidence
         run: |
-          echo "pushed=ghcr.io/HirakuArai/hello-ai:${{ github.event.inputs.tag }}" | tee -a reports/ghcr_publish.txt
+          echo "pushed=ghcr.io/${{ steps.who.outputs.owner_lc }}/hello-ai:${{ github.event.inputs.tag }}" | tee -a reports/ghcr_publish.txt

--- a/infra/argocd/apps/hello-ai-app.yaml
+++ b/infra/argocd/apps/hello-ai-app.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vpm-mini-hello-ai
   namespace: argocd
   annotations:
-    argocd-image-updater.argoproj.io/image-list: "hello-ai=ghcr.io/HirakuArai/hello-ai"
+    argocd-image-updater.argoproj.io/image-list: "hello-ai=ghcr.io/hirakuarai/hello-ai"
     argocd-image-updater.argoproj.io/hello-ai.update-strategy: "semver:~1"
     argocd-image-updater.argoproj.io/hello-ai.allow-tags: "regexp:^1\\..*"
 spec:


### PR DESCRIPTION
## Summary
OCI requires lowercase repository names. This patch lowercases owner in CI and Argo Image Updater annotations.

## Changes
- **GitHub Workflow**: Added step to derive lowercase owner using bash parameter expansion (`${GITHUB_REPOSITORY_OWNER,,}`)
- **Build & Push**: Uses lowercase owner for image tag (`ghcr.io/${owner_lc}/hello-ai`)
- **Image Updater**: Fixed annotation to use lowercase (`ghcr.io/hirakuarai/hello-ai`)

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

