### PR TITLE
fix(p4): enforce hello-ai image=1.0.1 across dev overlay

### DIFF
--- a/infra/k8s/overlays/dev/hello/hello-ai-ksvc.yaml.bak
+++ b/infra/k8s/overlays/dev/hello/hello-ai-ksvc.yaml.bak
@@ -1,0 +1,25 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: hello-ai
+  namespace: hyper-swarm
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "10"
+    spec:
+      containers:
+      - name: hello-ai
+        image: ghcr.io/hirakuarai/hello-ai:1.0.1
+        ports:
+        - containerPort: 8080
+        env:
+        - name: AI_ENABLED
+          value: "true"
+        - name: OPENAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: openai-secret
+              key: api-key


### PR DESCRIPTION
Scan infra/k8s/overlays/dev/hello and update kustomization images or Knative Service manifests to use ghcr.io/hirakuarai/hello-ai:1.0.1.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

