### PR TITLE
fix(p4): switch hello-ai to 1.0.1 (local arm64 image)

### DIFF
--- a/infra/k8s/overlays/dev/hello/hello-ai-ksvc.yaml
+++ b/infra/k8s/overlays/dev/hello/hello-ai-ksvc.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: hello-ai
-        image: ghcr.io/hirakuarai/hello-ai:1.0.0
+        image: ghcr.io/hirakuarai/hello-ai:1.0.1
         ports:
         - containerPort: 8080
         env:


### PR DESCRIPTION
## Summary
- Switch hello-ai from 1.0.0 to 1.0.1 
- Image 1.0.1 was built locally with arm64 support
- Resolves ImagePullBackOff platform mismatch issue

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

