### PR TITLE
feat(p5-2): SLO & Runbook 初版（p95<=1s, error<=1%）

### DIFF
--- a/dashboards/hello_ai_metrics.json
+++ b/dashboards/hello_ai_metrics.json
@@ -444,11 +444,185 @@
       ],
       "title": "Service Status",
       "type": "stat"
+    },
+    {
+      "type": "timeseries",
+      "title": "SLO p95 (<=1s)",
+      "id": 6,
+      "targets": [
+        {
+          "expr": "hello_ai:latency:p95:5m",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "options": {
+        "legend": {
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "SLO Error % (<=1%)",
+      "id": 7,
+      "targets": [
+        {
+          "expr": "hello_ai:error_rate:5m",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "options": {
+        "legend": {
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      }
     }
   ],
   "schemaVersion": 30,
   "style": "dark",
-  "tags": ["hello-ai", "slo", "metrics"],
+  "tags": [
+    "hello-ai",
+    "slo",
+    "metrics"
+  ],
   "templating": {
     "list": []
   },

--- a/docs/runbooks/hello_ai_slo_runbook.md
+++ b/docs/runbooks/hello_ai_slo_runbook.md
@@ -1,0 +1,24 @@
+# Runbook: hello-ai SLO 初版
+
+## SLO（初期値）
+- p95 latency ≤ 1s（5分移動窓）
+- Error rate ≤ 1%（5分移動窓）
+
+## 監視クエリ
+- p95: `hello_ai:latency:p95:5m`
+- Error %: `hello_ai:error_rate:5m`
+
+## 典型インシデントと対処
+### 1) p95 悪化
+- 負荷とPod数の相関をGrafanaで確認（QPS/Pod）
+- KPA設定の `target`（並行度）・CPU/メモリrequestsを調整
+- 影響が大きい場合は一時的に `minScale` を>0へ
+
+### 2) Error率上昇
+- 5xxのみか/特定routeかを分解（`{route=~"...",code=~"5.."}`）
+- 最近のデプロイ有無を確認、ロールバック手順に従う
+- 依存サービス/Secret切替・レート制限の確認
+
+## 参考
+- PrometheusRule: `infra/k8s/overlays/dev/monitoring/promrule-hello-ai-slo.yaml`
+- ダッシュボード: 「Hello AI / SLO」

--- a/infra/k8s/overlays/dev/monitoring/grafana-dashboard-hello-ai.yaml
+++ b/infra/k8s/overlays/dev/monitoring/grafana-dashboard-hello-ai.yaml
@@ -3,8 +3,7 @@ kind: ConfigMap
 metadata:
   name: grafana-dashboard-hello-ai
   namespace: monitoring
-  labels:
-    grafana_dashboard: "1"
+  labels: { grafana_dashboard: "1" }
 data:
   hello_ai_metrics.json: |
     {
@@ -453,11 +452,185 @@ data:
           ],
           "title": "Service Status",
           "type": "stat"
+        },
+        {
+          "type": "timeseries",
+          "title": "SLO p95 (<=1s)",
+          "id": 6,
+          "targets": [
+            {
+              "expr": "hello_ai:latency:p95:5m",
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              }
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 40
+          },
+          "options": {
+            "legend": {
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
+        },
+        {
+          "type": "timeseries",
+          "title": "SLO Error % (<=1%)",
+          "id": 7,
+          "targets": [
+            {
+              "expr": "hello_ai:error_rate:5m",
+              "refId": "A",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              }
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 48
+          },
+          "options": {
+            "legend": {
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
         }
       ],
       "schemaVersion": 30,
       "style": "dark",
-      "tags": ["hello-ai", "slo", "metrics"],
+      "tags": [
+        "hello-ai",
+        "slo",
+        "metrics"
+      ],
       "templating": {
         "list": []
       },

--- a/infra/k8s/overlays/dev/monitoring/promrule-hello-ai-slo.yaml
+++ b/infra/k8s/overlays/dev/monitoring/promrule-hello-ai-slo.yaml
@@ -1,0 +1,39 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: hello-ai-slo
+  namespace: monitoring
+  labels: { release: vpm-mini-kube-prometheus-stack }
+spec:
+  groups:
+  - name: hello-ai-slo-recordings
+    rules:
+    # p95 latency (5m window)
+    - record: hello_ai:latency:p95:5m
+      expr: |
+        histogram_quantile(
+          0.95,
+          sum by (le) (rate(hello_ai_request_duration_seconds_bucket[5m]))
+        )
+    # error rate % (5m window)
+    - record: hello_ai:error_rate:5m
+      expr: |
+        ( sum(rate(hello_ai_requests_total{code=~"5.."}[5m])) /
+          sum(rate(hello_ai_requests_total[5m])) ) * 100
+
+  - name: hello-ai-slo-alerts
+    rules:
+    - alert: HelloAI_SLO_P95_Breach
+      expr: hello_ai:latency:p95:5m > 1
+      for: 10m
+      labels: { severity: warning, slo: p95_lt_1s }
+      annotations:
+        summary: "hello-ai p95 latency SLO breach"
+        description: "p95 > 1s for 10m (current={{ $value | printf \"%.3fs\" }})"
+    - alert: HelloAI_SLO_ErrorRate_Breach
+      expr: hello_ai:error_rate:5m > 1
+      for: 10m
+      labels: { severity: warning, slo: error_lt_1pct }
+      annotations:
+        summary: "hello-ai error rate SLO breach"
+        description: "5xx error > 1% for 10m (current={{ $value | printf \"%.2f%%\" }})"

--- a/reports/p5_2_slo_runbook_20250913_060853.md
+++ b/reports/p5_2_slo_runbook_20250913_060853.md
@@ -1,0 +1,24 @@
+# P5-2 Evidence: SLO & Runbook 初版 (20250913_060853)
+
+## SLO
+- p95 <= 1s (5m) : recording = hello_ai:latency:p95:5m
+- Error% <= 1% (5m) : recording = hello_ai:error_rate:5m
+
+## Files
+- PrometheusRule: infra/k8s/overlays/dev/monitoring/promrule-hello-ai-slo.yaml
+- Dashboard CM: infra/k8s/overlays/dev/monitoring/grafana-dashboard-hello-ai.yaml
+- Runbook: docs/runbooks/hello_ai_slo_runbook.md
+
+## Verify
+- PrometheusRule hello-ai-slo created in monitoring namespace
+- Dashboard ConfigMap updated with SLO panels
+- Grafana dashboard now has "SLO p95 (<=1s)" and "SLO Error % (<=1%)" panels
+
+## Resources Applied
+- PrometheusRule: hello-ai-slo (contains recording rules and alerts)
+- ConfigMap: grafana-dashboard-hello-ai (updated with SLO panels)
+
+## Next Steps
+- Access Grafana to verify dashboard panels display SLO metrics
+- Monitor alerts when SLO thresholds are breached
+- Use runbook for incident response procedures


### PR DESCRIPTION
## Summary
- **P5-2 SLO Monitoring**: Prometheus recording rules and alerts for SLO tracking
- **SLO Targets**: p95 latency ≤1s, Error rate ≤1% (5min windows)
- **Recording Rules**: `hello_ai:latency:p95:5m` and `hello_ai:error_rate:5m`
- **Alerts**: `HelloAI_SLO_P95_Breach` and `HelloAI_SLO_ErrorRate_Breach` 
- **Dashboard**: Updated with SLO panels showing recording rule metrics
- **Runbook**: Initial incident response procedures for SLO violations
- **Evidence**: reports/p5_2_slo_runbook_20250913_060853.md

## SLO Configuration
- **P95 Latency SLO**: ≤1s (5m moving window)
  - Recording rule: `hello_ai:latency:p95:5m`
  - Alert: fires after 10min breach
- **Error Rate SLO**: ≤1% (5m moving window)
  - Recording rule: `hello_ai:error_rate:5m` 
  - Alert: fires after 10min breach

## Files Added/Modified
- `infra/k8s/overlays/dev/monitoring/promrule-hello-ai-slo.yaml`: SLO recording rules and alerts
- `infra/k8s/overlays/dev/monitoring/grafana-dashboard-hello-ai.yaml`: Updated dashboard ConfigMap
- `dashboards/hello_ai_metrics.json`: Added SLO panels (p95, error rate)
- `docs/runbooks/hello_ai_slo_runbook.md`: Incident response runbook

## Verification
- PrometheusRule `hello-ai-slo` deployed to monitoring namespace
- Dashboard ConfigMap updated with SLO panels
- Grafana will show new "SLO p95 (<=1s)" and "SLO Error % (<=1%)" panels

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/p5_2_slo_runbook_20250913_060853.md

