### PR TITLE
docs(state): tidy up P5 references (minimal cleanup)

### DIFF
--- a/STATE/current_state.md
+++ b/STATE/current_state.md
@@ -21,11 +21,11 @@ updated_at: 2025-09-15T00:00:00Z
 ## フェーズ構成と現在地
 - **Phase 0**：ローカル venv で 5ロール（対話→要約→プラン→エコー）一周の証跡化
 - **Phase 1**：Compose + 監視土台（完了）
-- **Phase 2（←現在地）**：kind + Knative（v1.18）足場 → Hello KService `READY=True / HTTP 200` の証跡化
+- **Phase 5（←現在地）**：kind + Knative（v1.18）足場 → Hello KService `READY=True / HTTP 200` の証跡化
 - 以降：サービス移植・Autoscale・観測ラインのK8s移行
 
 ## 現在地（C）
-- Phase 1 までの環境は main で安定
+- Phase 5 に移行：P5-1〜3 完了、P5-4（Secrets本番化）進行中
 - #128 により **Evidence Check（PR本文↔差分の不整合検知）** 導入済み
 - `.ops/deploy_freeze.json` は **true 維持**（不要なCDを抑止）
 - **欠落**：Phase 0 サニティ（5ロール一周の実行証跡）／ Phase 2 `hello-ksvc` READY 証跡
@@ -136,6 +136,12 @@ status: P4-AutoUpdate GREEN
 - Tag: p4-complete-20250913
 
 ## Phase 5: Scaling & Migration (Current)
+
+### Phase 5 Summary
+- 状態: In Progress（P5-1〜3 ✅ / P5-4 進行中）
+- 目的: Autoscale 反映、SLO/Runbook 定着、移植の継続、Secretsの本番化
+- 参照: reports/p5_* / SLOダッシュボード
+
 **Status**: In Progress (2025-09-13 ~ )
 
 ### Objectives

--- a/reports/p5_state_cleanup_20250915_052244.md
+++ b/reports/p5_state_cleanup_20250915_052244.md
@@ -1,0 +1,4 @@
+# Evidence: STATE cleanup for P5 (minimal)
+- 変更: Phase 2（←現在地）→ Phase 5（←現在地）、現在地サマリ追記
+- 目的: SSOTの見た目のズレ解消（読者混乱の回避）
+- 検証: 差分レビューのみ（機能変更なし）


### PR DESCRIPTION
## 目的
STATE の表記ゆれ（Phase 2→5）を最小整合し、現在地を Phase 5 として明確化する。

## 変更点
- 『フェーズ構成と現在地』の "←現在地" を Phase 5 へ
- 『現在地（C）』先頭の1行を Phase 5 用に最小補正
- Phase 5 Summary の短縮追記（In Progress）

context_header: repo=vpm-mini / branch=main / phase=Phase 5: Scaling & Migration

## Exit Criteria
- [x] 『Phase 2（←現在地）』→『Phase 5（←現在地）』
- [x] 現在地（C）先頭1行の最小補正
- [x] Evidence を PR に含める

## Evidence
- reports/p5_state_cleanup_20250915_052244.md
- STATE/current_state.md

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/p5_state_cleanup_20250915_052244.md

