### PR TITLE
chore(ci): add pre-DoD guard workflow

### DIFF
--- a/.github/workflows/pr_guard.yml
+++ b/.github/workflows/pr_guard.yml
@@ -1,0 +1,18 @@
+name: PR Guard (pre-DoD)
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check PR body for required sections
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BODY=$(gh pr view ${{ github.event.pull_request.number }} --json body -q .body)
+          reqs=("context_header:" "## Exit Criteria" "## Evidence" "## DoD チェックリスト（編集不可・完全一致）")
+          for r in "${reqs[@]}"; do
+            echo "$BODY" | grep -F "$r" >/dev/null || { echo "::error::Missing [$r] in PR body"; exit 1; }
+          done

--- a/reports/p5_pre_dod_guard_install_20250915_063114.md
+++ b/reports/p5_pre_dod_guard_install_20250915_063114.md
@@ -1,0 +1,4 @@
+# Evidence: pre-DoD Guard workflow の正式追加
+- 目的: DoD Enforcer で落ちる前に PR 本文の必須ブロック欠落を早期検出
+- 追加: .github/workflows/pr_guard.yml
+- 検証: 本PR本体でテンプレ遵守 + Evidence 同梱


### PR DESCRIPTION
## 目的
DoD Enforcer 前に PR 本文の必須ブロック不足を早期に検出し、PR安定性を向上させる。

## 変更点
- .github/workflows/pr_guard.yml を追加（pre-DoD guard）

context_header: repo=vpm-mini / branch=main / phase=Phase 5: Scaling & Migration

## Exit Criteria
- [x] pre-DoD guard ワークフローが追加される
- [x] このPR本文が必須ブロックを満たす
- [x] Evidence を PR に含める

## Evidence
- reports/p5_pre_dod_guard_install_20250915_063114.md

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/p5_pre_dod_guard_install_20250915_063114.md

