### PR TITLE
docs(trial): minimal handbook for Trial Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,12 @@ open http://localhost:3000  # (admin/admin)
 - 800 cells/sec 大規模負荷耐性確立
 - SSOT（運用ループの全体図）: `diagrams/src/ops_single_source_of_truth_v1.md`
 - ドキュメント目次: `docs/README.md`
+
+## Quick Start (Trial)
+1. フォームで `title/detail/project_id/priority` を投稿
+2. `status_query` で C/G/δ/Next を取得
+3. 日次5分: ダッシュボード→1改善PR（Evidence必須）
+
+- project_id: `vpm-core`
+- decision template: 結論 / 根拠（出典+時刻） / 次の一手 / 信頼度
+- scope: STATE / reports / PR(DoD) / Prometheus（意味軸/RAGなし）

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,6 @@
+# Observability Index
+- ダッシュボード: 「Hello AI / SLO」
+- 主要クエリ:
+  - p95: histogram_quantile(0.95, sum by (le)(rate(hello_ai_request_duration_seconds_bucket[5m])))
+  - Error%: (sum(rate(hello_ai_requests_total{code=~"5.."}[5m])) / sum(rate(hello_ai_requests_total[5m]))) * 100
+- 監視: ServiceMonitor targets up==1 / Alerts（Down/Latency/Error）

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -1,0 +1,5 @@
+# Trial Policies
+- 参照順（固定）：STATE → reports → PR(DoD) → Prometheus
+- 回答テンプレ：結論（1–3行） / 根拠（出典+時刻） / 次の一手（1–2点） / 信頼度（High|Med|Low）
+- Low時：**Low + 取得コマンド**（無理に埋めない）
+- WIP: `doing ≤ 2`、Daily: `1 PR`

--- a/docs/projects/vpm-core.md
+++ b/docs/projects/vpm-core.md
@@ -1,0 +1,9 @@
+# project_id: vpm-core
+## 目的
+P5 完走（P5-4 Secrets本番化 / SLO&Runbook定着 / 移植継続）
+## 成功判定
+- 週次バーンダウン（size=1） / DoD合致率 / 回帰%
+## seed backlog（size=1）
+- P5-4: Secrets 本番化（選定クラウドの SecretStore/ExternalSecret）
+- P5-5: SLO/Runbook 横展開
+- P5-6: CD 可視化（トレーシング/コスト）

--- a/docs/secrets_strategy.md
+++ b/docs/secrets_strategy.md
@@ -1,0 +1,5 @@
+# Secrets Strategy（Trial → Production）
+- Trial: K8s Secret / SOPS PoC（Gitに秘匿は載せない）
+- Production: クラウド Secret + 鍵レス認証（IRSA/Workload Identity 等）
+- ローテーション試験: 反映時間と挙動を Evidence 記録
+- 監査: 読み出しログ可視化と警報

--- a/reports/_templates.md
+++ b/reports/_templates.md
@@ -1,0 +1,10 @@
+# 日次 Evidence（雛形）
+- trace_id:
+- 今日の一手:
+- 主要SLO（p95/Error%/Restarts）:
+- 所感/学び:
+# 週次 Evidence（雛形）
+- バーンダウン:
+- DoD合致率:
+- 回帰%:
+- 次週TODO:


### PR DESCRIPTION
## 目的
試験運用の入口/参照/証跡を README 起点で統一し、迷わず回せる"器"を整える。

## 変更点
- README: Quick Start (Trial)
- docs/policies.md / docs/observability.md / docs/projects/vpm-core.md
- reports/_templates.md / docs/secrets_strategy.md

context_header: repo=vpm-mini / branch=main / phase=Phase 5: Scaling & Migration

## Exit Criteria
- [x] 上記6点のファイルが追加/更新
- [x] READMEから各ドキュメントへリンク
- [x] Evidence 雛形が `reports/_templates.md` に存在

## Evidence
- git diff（このPRの差分）

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/_templates.md

