### PR TITLE
docs: add single attachments index

### DIFF
--- a/docs/attachments_index.md
+++ b/docs/attachments_index.md
@@ -1,0 +1,11 @@
+# Attachments Index（Project Files to Reference）
+> ChatGPT の"添付"は原則この1枚に集約。最新版は常にリポから参照。
+
+- STATE（SSOT）: `STATE/current_state.md`
+- Trial Handbook:
+  - README Quick Start: `README.md`
+  - Policies: `docs/policies.md`
+  - Observability: `docs/observability.md`
+  - Project B: `docs/projects/vpm-core.md`
+- Evidence Templates: `reports/_templates.md`
+- Secrets Strategy: `docs/secrets_strategy.md`


### PR DESCRIPTION
## 目的
ChatGPT プロジェクトの"添付"を1枚に集約し、常に最新版のリポジトリを参照できるようにする。

## 変更点
- `docs/attachments_index.md` を追加（SSOT/Handbook/Evidenceへの導線を一本化）

context_header: repo=vpm-mini / branch=main / phase=Phase 5: Scaling & Migration

## Exit Criteria
- [x] `docs/attachments_index.md` が追加される
- [x] 今後の ChatGPT 側の添付はこの1枚で代替可能

## Evidence
- git diff（このPRの差分）

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

