### PR TITLE
feat(trial): status_query + daily review command + README index link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 **Dev URL (kind/8080):** `make hello-health` → 200 OK
+
+> 📎 Attachments: `docs/attachments_index.md`（ChatGPT の添付はこの1枚に集約）
+
 # vpm-mini
 
 **context_header:** repo=vpm-mini / branch=main / phase=Phase 2

--- a/reports/p5_status_query_and_daily_review_20250915_082753.md
+++ b/reports/p5_status_query_and_daily_review_20250915_082753.md
@@ -1,0 +1,4 @@
+# Evidence: status_query + daily review command
+- 追加: /api/v1/status_query（Watcher）
+- 追加: tools/vmp_trial_status.sh（ksvc/PR/targets/alerts）
+- README: attachments index 導線追記

--- a/services/watcher/app.py
+++ b/services/watcher/app.py
@@ -1,3 +1,9 @@
+import datetime
+import re
+import subprocess
+import time
+from pathlib import Path
+
 from fastapi import FastAPI, Request
 from prometheus_client import (
     Counter,
@@ -7,7 +13,6 @@ from prometheus_client import (
     generate_latest,
     CONTENT_TYPE_LATEST,
 )
-import time
 
 app = FastAPI(title="watcher")
 
@@ -42,3 +47,46 @@ async def metrics_mw(request: Request, call_next):
 @app.get("/metrics")
 def metrics():
     return generate_latest(registry), 200, {"Content-Type": CONTENT_TYPE_LATEST}
+
+
+def _read_state():
+    s = Path("STATE/current_state.md").read_text(encoding="utf-8")
+    phase = re.search(r"^phase:\s*(.+)", s, re.M)
+    phase = phase.group(1).strip() if phase else "UNKNOWN"
+    m_c = re.search(r"## 現在地（C）\n([\s\S]*?)(\n## |\Z)", s)
+    cur = m_c.group(1).strip().splitlines()[:2] if m_c else []
+    m_p5 = re.search(r"## Phase 5:[\s\S]*?\n([\s\S]*?)(\n## |\Z)", s)
+    p5 = m_p5.group(1).strip().splitlines()[:3] if m_p5 else []
+    return phase, cur, p5
+
+
+def _latest_reports(n=3):
+    try:
+        out = (
+            subprocess.check_output(
+                "ls -1t reports | head -n%d" % n, shell=True, text=True
+            )
+            .strip()
+            .splitlines()
+        )
+    except Exception:
+        out = []
+    return [f"reports/{x}" for x in out if x]
+
+
+@app.get("/api/v1/status_query")
+def status_query():
+    phase, cur, p5 = _read_state()
+    evidence = _latest_reports()
+    conclusion = f"現在地: {phase}. 直近: " + (
+        " / ".join(cur) if cur else "STATEの『現在地（C）』参照"
+    )
+    next_steps = ["日次5分レビュー実施（ダッシュボード確認→1改善PR）"]
+    confidence = "High" if "Phase 5" in phase else "Med"
+    return {
+        "conclusion": conclusion,
+        "evidence": evidence,
+        "next": next_steps,
+        "confidence": confidence,
+        "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+    }

--- a/tools/vmp_trial_status.sh
+++ b/tools/vmp_trial_status.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+APP_NS=${APP_NS:-hyper-swarm}
+REPO=${REPO:-HirakuArai/vpm-mini}
+
+echo "== KService (ns=$APP_NS) =="
+kubectl -n "$APP_NS" get ksvc -o wide || true
+
+echo "== Recent PRs =="
+gh pr list --repo "$REPO" --limit 5 || true
+echo "== Merged PRs =="
+gh pr list --repo "$REPO" --state merged --limit 5 || true
+
+PROM_SVC=$(kubectl -n monitoring get svc -o name 2>/dev/null | grep -E 'prometheus.*' | head -n1 | cut -d/ -f2)
+if [ -n "${PROM_SVC:-}" ]; then
+  (kubectl -n monitoring port-forward "svc/${PROM_SVC}" 9091:9090 >/dev/null 2>&1 & echo $! > /tmp/pf_prom.pid)
+  sleep 1
+  echo "== Targets (hello-ai & peers) =="
+  curl -s http://localhost:9091/api/v1/targets | jq '.data.activeTargets[]|{job:.labels.job,health:.health}|select(.job|test("hello-ai|watcher|curator|planner|synthesizer|archivist"))' || true
+  echo "== Alerts (HelloAI* / SLO*) =="
+  curl -s http://localhost:9091/api/v1/alerts | jq '.data.alerts[]?|select(.labels.alertname|test("HelloAI|SLO"))|{name:.labels.alertname,state:.state,activeAt:.activeAt}' || true
+  kill $(cat /tmp/pf_prom.pid) 2>/dev/null || true
+else
+  echo "Prometheus service not found in monitoring ns."
+fi


### PR DESCRIPTION
## 目的
試験運用で"いまどこ？次は？"を即答し、日次5分レビューを回しやすくする。

## 変更点
- Watcher: `/api/v1/status_query` を追加（SSOT決め打ち参照）
- tools: `tools/vmp_trial_status.sh` を追加（日次レビュー集約）
- README: `docs/attachments_index.md` への導線を追記

context_header: repo=vpm-mini / branch=main / phase=Phase 5: Scaling & Migration

## Exit Criteria
- [x] `/api/v1/status_query` が応答
- [x] 日次レビューコマンドで ksvc/PR/targets/alerts が一括出力
- [x] README に Attachments Index の導線

## Evidence
- reports/p5_status_query_and_daily_review_20250915_082753.md

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/p5_status_query_and_daily_review_20250915_082753.md

