### PR TITLE
chore(trial): day-1 routine + seed backlog (vpm-core)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,11 @@ verify:
 	git ls-remote --tags origin | grep -q "refs/tags/$${SLUG}" \
 	  && echo "OK: tag $${SLUG}" \
 	  || (echo "MISSING: tag $${SLUG}"; exit 1)
+
+# === Trial Mode ===
+trial-daily:
+	@chmod +x tools/vpm_trial_status.sh tools/vpm_daily_capture.sh 2>/dev/null || true
+	@echo "== Trial Daily Status =="
+	@tools/vpm_trial_status.sh || true
+	@echo "== Capture Evidence =="
+	@tools/vpm_daily_capture.sh

--- a/README.md
+++ b/README.md
@@ -74,3 +74,11 @@ open http://localhost:3000  # (admin/admin)
 - project_id: `vpm-core`
 - decision template: 結論 / 根拠（出典+時刻） / 次の一手 / 信頼度
 - scope: STATE / reports / PR(DoD) / Prometheus（意味軸/RAGなし）
+
+### Trial Daily (5分レビュー)
+```
+make trial-daily
+```
+- KService / PR / Targets / Alerts を表示
+- `reports/daily_status_*.md` にEvidence保存
+

--- a/reports/p5_trial_day1_setup_20250915_094643.md
+++ b/reports/p5_trial_day1_setup_20250915_094643.md
@@ -1,0 +1,4 @@
+# Evidence: Trial Day-1 setup
+- Makefile に trial-daily タスクを追加
+- README に trial-daily の使い方を追記
+- vpm-core backlog を Issue 化（seed 5件）


### PR DESCRIPTION
## 目的
Trial Mode を"回し続ける"状態にする（日次ルーチンと最初の改善Backlogを整備）。

## 変更点
- Makefile: `trial-daily` タスクを追加（status + evidence 保存）
- README: `make trial-daily` の使い方を追記
- Issue: vpm-core の seed backlog を起票（5件）

context_header: repo=vpm-mini / branch=main / phase=Phase 5: Scaling & Migration

## Exit Criteria
- [x] `make trial-daily` で日次Evidenceが保存される
- [x] README から trial-daily 手順が分かる
- [x] vpm-core に最初の Backlog が起票済み（5件）

## Evidence
- reports/p5_trial_day1_setup_*.md

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/p5_trial_day1_setup_20250915_094643.md

