### PR TITLE
feat(watcher): status_query extension (prom targets + latest tag/PR)

### DIFF
--- a/reports/p5_status_query_ext_20250915_095548.md
+++ b/reports/p5_status_query_ext_20250915_095548.md
@@ -1,0 +1,3 @@
+# Evidence: status_query extension (Prom targets + latest tag/PR)
+- 返却フィールド: prom_targets / latest_tag / recent_merged_pr を追加
+- Prometheus in-cluster URL: ENV PROM_INCLUSTER_URL で上書き可

--- a/services/watcher/app.py
+++ b/services/watcher/app.py
@@ -1,7 +1,11 @@
 import datetime
+import json
+import os
 import re
 import subprocess
 import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 from fastapi import FastAPI, Request
@@ -81,12 +85,76 @@ def status_query():
     conclusion = f"現在地: {phase}. 直近: " + (
         " / ".join(cur) if cur else "STATEの『現在地（C）』参照"
     )
-    next_steps = ["日次5分レビュー実施（ダッシュボード確認→1改善PR）"]
+    next_steps = ["日次5分レビュー（ダッシュボード→1改善PR）"]
     confidence = "High" if "Phase 5" in phase else "Med"
+
+    prom = _prom_targets_summary()
+    tag = _git_latest_tag()
+    pr = _recent_merged_pr()
+
     return {
         "conclusion": conclusion,
         "evidence": evidence,
         "next": next_steps,
         "confidence": confidence,
+        "prom_targets": prom,
+        "latest_tag": tag,
+        "recent_merged_pr": pr,
         "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
     }
+
+
+PROM_INCLUSTER = os.getenv(
+    "PROM_INCLUSTER_URL",
+    "http://vpm-mini-kube-prometheus-stack-prometheus.monitoring.svc:9090/api/v1",
+)
+
+
+def _prom_targets_summary():
+    url = f"{PROM_INCLUSTER}/targets"
+    try:
+        with urllib.request.urlopen(url, timeout=0.8) as r:
+            data = json.loads(r.read().decode("utf-8"))
+        active = data.get("data", {}).get("activeTargets", []) or []
+        # hello-ai & peers の up 数だけ集計
+        focus = [
+            "hello-ai",
+            "watcher",
+            "curator",
+            "planner",
+            "synthesizer",
+            "archivist",
+        ]
+        up = {j: 0 for j in focus}
+        for tgt in active:
+            job = tgt["labels"].get("job", "")
+            if job in up and tgt.get("health") == "up":
+                up[job] += 1
+        return {"total": len(active), "up": up}
+    except Exception:
+        return {
+            "note": "prometheus query skipped/failed (check network or service name)"
+        }
+
+
+def _git_latest_tag():
+    try:
+        tag = subprocess.check_output(
+            "git describe --tags --abbrev=0", shell=True, text=True, timeout=0.8
+        ).strip()
+        return tag
+    except Exception:
+        return None
+
+
+def _recent_merged_pr():
+    try:
+        out = subprocess.check_output(
+            "gh pr list --state merged --limit 1 --json number,title,mergedAt -q '.[0]'",
+            shell=True,
+            text=True,
+            timeout=1.2,
+        )
+        return json.loads(out)
+    except Exception:
+        return None


### PR DESCRIPTION
## 目的
status_query に Prometheus targets ヘルスと最新タグ/直近マージPRを含め、即答の質を1段上げる。

## 変更点
- Watcher: `/api/v1/status_query` へ `prom_targets / latest_tag / recent_merged_pr` を追加
- Evidence: 追加

context_header: repo=vpm-mini / branch=main / phase=Phase 5: Scaling & Migration

## Exit Criteria
- [x] `/api/v1/status_query` が上記3フィールドを返す
- [x] Evidence を PR に含める

## Evidence
- reports/p5_status_query_ext_*.md

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新