### PR TITLE
docs(adr): P5-4 Secrets backend selection (proposal) + scaffold

### DIFF
--- a/docs/adr/adr_20250915_105551_secrets_backend_selection.md
+++ b/docs/adr/adr_20250915_105551_secrets_backend_selection.md
@@ -1,0 +1,31 @@
+# ADR: Secrets backend selection (P5-4)
+
+## Status
+Proposed
+
+## Context
+- Trial: K8s Secret / SOPS PoC（Gitに秘匿は載せない）
+- Production: 鍵レス認証 + 監査（IAM / Workload Identity / Managed Identity / Vault Auth）
+
+## Decision Options
+- AWS Secrets Manager (+ IRSA)
+- GCP Secret Manager (+ Workload Identity)
+- Azure Key Vault (+ Managed Identity)
+- HashiCorp Vault (+ Kubernetes Auth)
+
+## Decision Criteria
+- 最小権限（鍵レス） / 監査容易性 / 既存インフラ親和性 / 運用コスト / 料金
+
+## Decision
+- T.B.D.（次セッションで確定）
+
+## Consequences
+- SecretStore/ClusterSecretStore + ExternalSecret を provider に応じて適用
+- ローテーション試験を Evidence へ記録し、SOPS PoC を撤去
+
+## Rollout Plan
+1) Secret backend 選定（ADRを決定状態へ）
+2) (Cluster)SecretStore（鍵レス認証）作成
+3) ExternalSecret 1本（例: am-slack-receiver）を同期
+4) ローテーション試験（反映時間/挙動の記録）
+5) SOPS PoC の撤去と README/STATE 更新

--- a/infra/k8s/overlays/dev/secrets/README.md
+++ b/infra/k8s/overlays/dev/secrets/README.md
@@ -1,0 +1,5 @@
+# Secrets overlay (P5-4)
+本番化決定後、選定したクラウドに合わせて以下を追加:
+- (Cluster)SecretStore（鍵レス認証）
+- ExternalSecret（例: am-slack-receiver）
+- ローテーション試験の手順と Evidence リンク

--- a/reports/p5_4_secrets_adr_20250915_105620.md
+++ b/reports/p5_4_secrets_adr_20250915_105620.md
@@ -1,0 +1,9 @@
+# Evidence: P5-4 Secrets 本番化 — ADR起票＋スキャフォールド
+
+## 追加
+- ADR: docs/adr/adr_20250915_105551_secrets_backend_selection.md
+- overlay: infra/k8s/overlays/dev/secrets/README.md
+
+## 次
+- 次セッションで backend を決定（AWS/GCP/Azure/Vault から選定）
+- SecretStore/ExternalSecret を実装 → ローテーション試験


### PR DESCRIPTION
## 目的
P5-4（Secrets本番化）に先立ち、選定と実装計画を ADR として記録し、最小の overlay を用意する。

## 変更点
- docs/adr: secrets backend selection（提案）
- infra/k8s/overlays/dev/secrets: scaffold（決定後に SecretStore/ExternalSecret を実装）

context_header: repo=vpm-mini / branch=main / phase=Phase 5: Scaling & Migration

## Exit Criteria
- [x] ADR が main に記録される
- [x] secrets overlay の置き場が用意される
- [x] Evidence を PR に含める

## Evidence
- reports/p5_4_secrets_adr_*.md

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/p5_4_secrets_adr_20250915_105620.md

