### PR TITLE
feat(state-view): generate C/G/δ report from STATE and save to reports

### DIFF
--- a/.github/workflows/state_view.yml
+++ b/.github/workflows/state_view.yml
@@ -1,0 +1,82 @@
+name: State View Generator
+
+on:
+  workflow_dispatch:
+    inputs:
+      state_file:
+        description: 'State file path (relative to repo root)'
+        required: false
+        default: 'STATE/current_state.md'
+        type: string
+
+jobs:
+  generate-state-view:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Verify state file exists
+      run: |
+        if [ ! -f "${{ github.event.inputs.state_file }}" ]; then
+          echo "State file not found: ${{ github.event.inputs.state_file }}"
+          exit 1
+        fi
+        echo "State file found: ${{ github.event.inputs.state_file }}"
+        echo "File size: $(wc -c < "${{ github.event.inputs.state_file }}") bytes"
+
+    - name: Generate state view report
+      run: |
+        # Make script executable
+        chmod +x scripts/state_view.py
+
+        # Generate report
+        python3 scripts/state_view.py --in "${{ github.event.inputs.state_file }}"
+
+        # Show generation results
+        echo "Generated files:"
+        ls -la reports/p2_state_view_*.md 2>/dev/null || echo "No files generated"
+
+    - name: Display generated report
+      run: |
+        LATEST_REPORT=$(ls -t reports/p2_state_view_*.md 2>/dev/null | head -1)
+        if [ -n "$LATEST_REPORT" ]; then
+          echo "=== Generated Report Content ==="
+          cat "$LATEST_REPORT"
+        else
+          echo "No report file found"
+          exit 1
+        fi
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: state-view-report
+        path: |
+          reports/p2_state_view_*.md
+        retention-days: 30
+
+    - name: Summary
+      run: |
+        LATEST_REPORT=$(ls -t reports/p2_state_view_*.md 2>/dev/null | head -1)
+        if [ -n "$LATEST_REPORT" ]; then
+          echo "## State View Generation Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **State File**: ${{ github.event.inputs.state_file }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Generated Report**: $LATEST_REPORT" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status**: ✅ Success" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Report Preview" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`markdown" >> $GITHUB_STEP_SUMMARY
+          head -20 "$LATEST_REPORT" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "## State View Generation Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status**: ❌ Failed - No report generated" >> $GITHUB_STEP_SUMMARY
+        fi

--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,8 @@ trial-ui-smoke-port:
 	 -H 'content-type: application/json' \
 	 -d '{"title":"smoke","description":"auto","priority":"low"}' \
 	| jq -r '.trace_id' | xargs -I{} echo "TRACE={}"
+
+# === State View ===
+.PHONY: state-view
+state-view:
+	python3 scripts/state_view.py

--- a/STATE/current_state.md
+++ b/STATE/current_state.md
@@ -1,5 +1,11 @@
 # VPM-Mini Trial State
 
+active_repo: vpm-mini
+active_branch: main
+phase: Phase 5 (Scaling & Migration)
+context_header: repo=vpm-mini / branch=main / phase=Phase 5 Trial
+short_goal: Complete P5-5 Consumer Injection and advance to P5-6 Observability
+
 ## Phase Progress
 - **P1** (Foundation): ✅ GREEN  
 - **P2** (Chaos Engineering): ✅ GREEN
@@ -25,11 +31,17 @@
 - P5-2 UI: reports/ui_manual_evidence_20250916_153047.md
 - P5-4 Vault: reports/p5_4_secrets_vault_verify_20250916_171916.md
 
-## Next Immediate Actions
-1. **Consumer workload selection**: Identify which service needs secrets
-2. **Secret preparation**: Create production secret in Vault (API keys, DB credentials)  
-3. **KService injection**: Add secretKeyRef to selected service
-4. **End-to-end test**: Verify secret available in pod environment
-5. **Evidence collection**: Document consumption via pod exec
+## exit_criteria
+- P5-5 Consumer Injection completed with evidence
+- Secret consumption verified in running pods
+- KService secretKeyRef integration tested
+- P5-6 Observability Line ready for execution
+
+## 優先タスク
+- Consumer workload selection: Identify which service needs secrets
+- Secret preparation: Create production secret in Vault (API keys, DB credentials)
+- KService injection: Add secretKeyRef to selected service
+- End-to-end test: Verify secret available in pod environment
+- Evidence collection: Document consumption via pod exec
 
 Updated: 2025-09-16T20:23:15Z

--- a/docs/state_view_spec.md
+++ b/docs/state_view_spec.md
@@ -1,0 +1,184 @@
+# State View Specification
+
+## 概要
+`scripts/state_view.py` は STATE/current_state.md を機械可読から人間可読な Markdown レポートに変換し、現在地(C) / ゴール(G) / 差分(δ) / 次アクションを自動出力します。
+
+## 入力/出力
+
+### 入力
+- **デフォルト**: `STATE/current_state.md`
+- **カスタム**: `--in <path>` で指定可能
+- **形式**: Markdown ファイル（key: value 形式または見出し＋箇条書き）
+
+### 出力
+- **デフォルト**: `reports/p2_state_view_YYYYMMDD_HHMM.md`
+- **カスタム**: `--out <path>` で指定可能
+- **形式**: 構造化された Markdown レポート
+
+## 抽出キー
+
+スクリプトは以下のキーを STATE ファイルから抽出します：
+
+### 必須キー
+1. **active_repo**: 作業中のリポジトリ名
+2. **active_branch**: 作業中のブランチ名
+3. **phase**: 現在のフェーズ（例: "Phase 2"）
+4. **context_header**: コンテキスト情報
+5. **short_goal**: 短期目標
+6. **exit_criteria**: 完了条件（箇条書き可）
+7. **優先タスク**: 実行すべきタスク一覧（箇条書き可）
+
+### 抽出形式
+#### key: value 形式
+```markdown
+active_repo: vpm-mini
+active_branch: main
+phase: Phase 2
+```
+
+#### 見出し＋箇条書き形式
+```markdown
+## 優先タスク
+- タスク1の説明
+- タスク2の説明
+- タスク3の説明
+```
+
+## 出力構成
+
+生成される Markdown レポートは以下の構造を持ちます：
+
+### 1. 現在地 (C)
+```markdown
+# 現在地 (C)
+- repo: `vpm-mini`
+- branch: `main`
+- phase: **Phase 2**
+- context: repo=vpm-mini / branch=main / phase=Phase 2
+```
+
+### 2. ゴール (G)
+```markdown
+# ゴール (G)
+- short_goal: プロジェクトの短期目標
+- exit_criteria:
+  - 完了条件1
+  - 完了条件2
+  - 完了条件3
+```
+
+### 3. 差分 (δ)
+```markdown
+# 差分 (δ)
+- 未達Exitの補充・検証を優先
+- 優先タスクを先頭から実行し証跡化
+```
+
+### 4. 次アクション（最大3件）
+```markdown
+# 次アクション（最大3件）
+- 優先タスク1
+- 優先タスク2
+- 優先タスク3
+```
+
+### 5. メタデータ
+```markdown
+---
+Generated: YYYY-MM-DD HH:MM:SS
+Source: STATE/current_state.md
+Total tasks: N
+```
+
+## エラー処理
+
+### 必須キー欠損時
+- 欠損したキー名を標準エラー出力に表示
+- 終了コード 1 で終了（CI で検知可能）
+
+### ファイル不存在時
+- エラーメッセージを標準エラー出力に表示
+- 終了コード 1 で終了
+
+### 成功時の出力例
+```
+[state-view] reading: STATE/current_state.md
+[state-view] file size: 1234 chars, 56 lines
+[extract] active_repo: vpm-mini
+[extract] active_branch: main
+[extract] phase: Phase 2
+[extract] context_header: repo=vpm-mini / branch=main / phase=Phase 2
+[extract] short_goal: プロジェクトの目標説明
+[extract] exit_criteria: 3 items
+[extract] 優先タスク: 5 items
+[state-view] written: reports/p2_state_view_20250919_0615.md (1456 chars)
+[state-view] extracted keys: active_repo, active_branch, phase, context_header, short_goal, exit_criteria, 優先タスク
+```
+
+## 使用方法
+
+### コマンドライン実行
+```bash
+# デフォルト設定で実行
+python3 scripts/state_view.py
+
+# カスタム入力/出力ファイル指定
+python3 scripts/state_view.py --in custom_state.md --out custom_report.md
+
+# ヘルプ表示
+python3 scripts/state_view.py --help
+```
+
+### Makefile 経由
+```bash
+# 標準実行
+make state-view
+```
+
+### GitHub Actions
+```bash
+# 手動実行ワークフロー
+# Actions タブ → "state-view" → "Run workflow"
+```
+
+## 運用方針
+
+### PR作成時の使用
+1. PR作成前に `make state-view` を実行
+2. 生成されたレポートを Evidence として PR に添付
+3. 以後の判断・修正はこのレポートを根拠とする
+
+### 会話のSSOT (Single Source of Truth)
+- 現在の状況把握の統一基準
+- 次のアクション決定の根拠
+- 進捗確認とゴール設定の基盤
+
+## ファイル依存関係
+
+### 入力依存
+- `STATE/current_state.md` （または指定ファイル）
+
+### 出力生成
+- `reports/p2_state_view_*.md`
+
+### ディレクトリ自動作成
+- `reports/` ディレクトリが存在しない場合は自動作成
+
+## 技術仕様
+
+### 言語・環境
+- Python 3.x
+- 標準ライブラリのみ使用（外部依存なし）
+
+### 文字エンコーディング
+- 入力/出力共に UTF-8
+
+### 正規表現パターン
+- key: value 抽出: `^{key}\s*:\s*(.+)$`
+- 見出し抽出: `^#+\s*{key}[^\n]*\n((?:- .+\n?)+)`
+
+## バージョン情報
+
+- **Version**: 1.0
+- **Author**: Generated from specification
+- **License**: Same as project license

--- a/reports/p2_state_view_20250919_0617.md
+++ b/reports/p2_state_view_20250919_0617.md
@@ -1,0 +1,27 @@
+# 現在地 (C)
+- repo: `vpm-mini`
+- branch: `main`
+- phase: **Phase 5 (Scaling & Migration)**
+- context: repo=vpm-mini / branch=main / phase=Phase 5 Trial
+
+# ゴール (G)
+- short_goal: Complete P5-5 Consumer Injection and advance to P5-6 Observability
+- exit_criteria:
+  - P5-5 Consumer Injection completed with evidence
+  - Secret consumption verified in running pods
+  - KService secretKeyRef integration tested
+  - P5-6 Observability Line ready for execution
+
+# 差分 (δ)
+- 未達Exitの補充・検証を優先
+- 優先タスクを先頭から実行し証跡化
+
+# 次アクション（最大3件）
+- Consumer workload selection: Identify which service needs secrets
+- Secret preparation: Create production secret in Vault (API keys, DB credentials)
+- KService injection: Add secretKeyRef to selected service
+
+---
+Generated: 2025-09-19 06:17:42
+Source: STATE/current_state.md
+Total tasks: 5

--- a/scripts/state_view.py
+++ b/scripts/state_view.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+import argparse
+import datetime
+import pathlib
+import re
+import sys
+
+REQ_KEYS = [
+    "active_repo",
+    "active_branch",
+    "phase",
+    "context_header",
+    "short_goal",
+    "exit_criteria",
+    "優先タスク",
+]
+
+
+def read_text(p):
+    return pathlib.Path(p).read_text(encoding="utf-8")
+
+
+def extract_sections(md: str):
+    # 粗いが堅牢な抽出：key: value 形式と見出し下の箇条書き双方を許容
+    found = {}
+    for k in REQ_KEYS:
+        # key: value 行
+        m = re.search(rf"^{re.escape(k)}\s*:\s*(.+)$", md, re.MULTILINE)
+        if m:
+            found[k] = m.group(1).strip()
+            print(f"[extract] {k}: {m.group(1).strip()[:50]}...", file=sys.stderr)
+            continue
+        # 見出し版（例：## 優先タスク の箇条書き）
+        m2 = re.search(rf"^#+\s*{re.escape(k)}[^\n]*\n((?:- .+\n?)+)", md, re.MULTILINE)
+        if m2:
+            items = [
+                line[2:].strip()
+                for line in m2.group(1).strip().splitlines()
+                if line.startswith("- ")
+            ]
+            found[k] = items
+            print(f"[extract] {k}: {len(items)} items", file=sys.stderr)
+    return found
+
+
+def as_list(v):
+    if v is None:
+        return []
+    return v if isinstance(v, list) else [v]
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Generate C/G/δ view from STATE")
+    ap.add_argument(
+        "--in",
+        dest="inp",
+        default="STATE/current_state.md",
+        help="Input STATE file (default: STATE/current_state.md)",
+    )
+    ap.add_argument(
+        "--out",
+        dest="outp",
+        default=None,
+        help="Output file (default: reports/p2_state_view_YYYYMMDD_HHMM.md)",
+    )
+    args = ap.parse_args()
+
+    src = pathlib.Path(args.inp)
+    if not src.exists():
+        print(f"[state-view] missing file: {src}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"[state-view] reading: {src}", file=sys.stderr)
+    md = read_text(src)
+    print(
+        f"[state-view] file size: {len(md)} chars, {len(md.splitlines())} lines",
+        file=sys.stderr,
+    )
+
+    data = extract_sections(md)
+
+    missing = [k for k in REQ_KEYS if k not in data or data[k] in (None, "", [])]
+    if missing:
+        print(f"[state-view] missing keys: {', '.join(missing)}", file=sys.stderr)
+        sys.exit(1)
+
+    now = datetime.datetime.now().strftime("%Y%m%d_%H%M")
+    outp = (
+        pathlib.Path(args.outp)
+        if args.outp
+        else pathlib.Path(f"reports/p2_state_view_{now}.md")
+    )
+
+    # Ensure reports directory exists
+    outp.parent.mkdir(parents=True, exist_ok=True)
+
+    # 現在地 (C)
+    C = [
+        f"- repo: `{data['active_repo']}`",
+        f"- branch: `{data['active_branch']}`",
+        f"- phase: **{data['phase']}**",
+        f"- context: {data['context_header']}",
+    ]
+
+    # ゴール (G)
+    G = [
+        f"- short_goal: {data['short_goal']}",
+        "- exit_criteria:",
+    ] + [f"  - {x}" for x in as_list(data["exit_criteria"])]
+
+    # 優先タスク取得
+    tasks = as_list(data["優先タスク"])
+
+    # 差分 (δ)
+    delta_lines = [
+        "- 未達Exitの補充・検証を優先",
+        "- 優先タスクを先頭から実行し証跡化",
+    ][:2]
+
+    # 次アクション（最大3件）
+    next_actions = [f"- {t}" for t in tasks[:3]] or ["- （未定義）"]
+
+    # 出力構成
+    out_md = "\n".join(
+        [
+            "# 現在地 (C)",
+            *C,
+            "",
+            "# ゴール (G)",
+            *G,
+            "",
+            "# 差分 (δ)",
+            *delta_lines,
+            "",
+            "# 次アクション（最大3件）",
+            *next_actions,
+            "",
+            "---",
+            f"Generated: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+            f"Source: {src}",
+            f"Total tasks: {len(tasks)}",
+        ]
+    )
+
+    outp.write_text(out_md, encoding="utf-8")
+    print(f"[state-view] written: {outp} ({len(out_md)} chars)", file=sys.stderr)
+    print(f"[state-view] extracted keys: {', '.join(data.keys())}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
context_header: repo=vpm-mini / branch=main / phase=Phase 2

## Summary
STATE から C/G/δ を抽出して報告書を自動生成し、以後の判断の根拠を標準化します。

## Changes
- **scripts/state_view.py**: STATE → 人間可読な C/G/δ/Next Actions レポート生成
- **Makefile**: state-view ターゲット追加で簡単実行
- **docs/state_view_spec.md**: 完全な仕様書と使用方法ガイド
- **.github/workflows/state_view.yml**: 手動実行ワークフローとartifacts保存
- **STATE/current_state.md**: スクリプト互換性のため必須キー追加
- **reports/p2_state_view_20250919_0617.md**: 初回Evidence生成

## Exit Criteria
- [x] make state-view が成功（非0終了なし）
- [x] reports/p2_state_view_* が生成・コミット済み
- [x] Guard / DoD Enforcer すべて Pass

## Evidence
- reports/p2_state_view_20250919_0617.md

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## Features
- **機械可読→人間可読**: STATE の構造化データを分かりやすいレポートに変換
- **C/G/δ フレームワーク**: 現在地・ゴール・差分・次アクションの明確化
- **判断根拠の標準化**: 以後の提案・修正PRはこのレポートを根拠とする
- **CI統合**: GitHub Actions での自動実行とartifacts保存

## Usage
```bash
# ローカル実行
make state-view

# カスタム入力/出力
python3 scripts/state_view.py --in custom.md --out custom_report.md

# GitHub Actions
# Actions → "State View Generator" → "Run workflow"
```

## Impact
ツール・ドキュメント追加のみ（既存挙動に影響なし）

## Rollback
追加ファイル削除で元状態に戻る

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/p2_state_view_20250919_0617.md

