### PR TITLE
chore: trigger PR Validate checks (ruleset calibration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,6 @@ make trial-daily
 - KService / PR / Targets / Alerts を表示
 - `reports/daily_status_*.md` にEvidence保存
 
+---
+chore: trigger PR Validate (k8s-validate / knative-ready / evidence-dod) for ruleset calibration.
+

--- a/README.md
+++ b/README.md
@@ -85,3 +85,4 @@ make trial-daily
 ---
 chore: trigger PR Validate (k8s-validate / knative-ready / evidence-dod) for ruleset calibration.
 
+


### PR DESCRIPTION
このPRはチェック名観測用。マージ不要でも可。

## 目的
PR Validate の3ジョブ（k8s-validate / knative-ready / evidence-dod）を main 上で観測し、ruleset に正しいチェック名を設定するための bootstrap PR。

## 変更内容
README.md に1行追記のみ（実質的な機能変更なし）

## 次のアクション
- CI 実行完了を待機
- チェック名を確認
- ruleset を更新
- このPRはマージしてもしなくても可

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

