### PR TITLE
chore(state): mark P2-2 GREEN + evidence

### DIFF
--- a/STATE/current_state.md
+++ b/STATE/current_state.md
@@ -1,3 +1,11 @@
+# ✅ P2-2 GREEN（Hello KService）
+
+- Checks（標準3本）: **pr-validate / k8s-validate・/ knative-ready・/ evidence-dod → All Green**
+- Evidence: `reports/evidence_kservice_ready_20250928_015512.md`
+- DoD: `kubectl get ksvc hello → READY=True` を満たした（VPM v0 初運転成功）
+- PR: #305
+- Snapタグ予定: `p2-2-green-20250928`
+
 # Check-in 2025-09-28
 - P2-2: Hello KService を本日検証（DoD: READY=True）
 


### PR DESCRIPTION
## 目的
SSOTを更新してP2-2 GREENと証跡を刻む

## 変更内容
STATE/current_state.md の先頭に P2-2 GREEN ブロックを追加

## 記録内容
- ✅ 標準3本チェック: すべてGreen
- ✅ Evidence: reports/evidence_kservice_ready_20250928_015512.md
- ✅ DoD: READY=True 確認済み
- ✅ PR: #305 (VPM v0 初運転成功)

## Exit Criteria
- ✅ CI checks pass
- ✅ SSOT updated with P2-2 GREEN milestone

## Evidence
VPM v0 初運転成功の証跡をSSOTに記録

context_header: p2-2-green-ssot-update

## DoD チェックリスト（編集不可・完全一致）
- [ ] Auto-merge (squash) 有効化
- [ ] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [ ] merged == true を API で確認
- [ ] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [ ] 必要な証跡（例: reports/*）を更新