### PR TITLE
feat(diag): add workflow_dispatch for manual run (temporary)

### DIFF
--- a/.github/workflows/diag_required_vs_reported.yml
+++ b/.github/workflows/diag_required_vs_reported.yml
@@ -3,6 +3,11 @@ name: diag-required-vs-reported
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to comment to (manual test)"
+        required: true
 
 permissions:
   contents: read
@@ -12,11 +17,10 @@ permissions:
 
 jobs:
   diag:
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
       - uses: actions/checkout@v4
 
@@ -27,6 +31,25 @@ jobs:
 
       - name: Install deps (PyYAML only)
         run: pip install --disable-pip-version-check --quiet pyyaml
+
+      - name: Resolve PR number
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "PR_NUMBER=${{ github.event.inputs.pr_number }}" >> "$GITHUB_ENV"
+          else
+            echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Resolve head sha
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            HEAD_SHA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.inputs.pr_number }} --jq .head.sha)
+          else
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          fi
+          echo "HEAD_SHA=$HEAD_SHA" >> "$GITHUB_ENV"
 
       - name: Read required from config (robust YAML)
         id: req
@@ -45,7 +68,7 @@ PY
         id: rep
         shell: bash
         run: |
-          gh api repos/${{ github.repository }}/commits/${HEAD_SHA}/check-runs \
+          gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs \
             -H "Accept: application/vnd.github+json" --jq '.check_runs[].name' |
           jq -R -s 'split("\n")|map(select(length>0))|unique|sort' > reported.json
           echo "reported=$(cat reported.json)" >> "$GITHUB_OUTPUT"
@@ -59,6 +82,7 @@ PY
 
       - name: Upsert PR comment
         run: |
+          PR=$PR_NUMBER
           MARK="<!-- diag-required-vs-reported -->"
           REQ=$(jq -r '.required|join(", ")' diff.json)
           REP=$(jq -r '.reported|join(", ")' diff.json)
@@ -71,10 +95,10 @@ PY
 **missing**: $MIS
 **extra**: $EXT
 "
-          CID=$(gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments \
+          CID=$(gh api repos/${{ github.repository }}/issues/$PR/comments \
                 --jq '.[] | select(.body|contains("diag-required-vs-reported")) | .id' || true)
           if [ -n "$CID" ]; then
             gh api repos/${{ github.repository }}/issues/comments/$CID -X PATCH -f body="$BODY" >/dev/null
           else
-            gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments -f body="$BODY" >/dev/null
+            gh api repos/${{ github.repository }}/issues/$PR/comments -f body="$BODY" >/dev/null
           fi


### PR DESCRIPTION
## 目的
diag-required-vs-reported を **手動実行（workflow_dispatch）** できるようにし、
#314 で「required vs reported の自動コメント」が付くか即時確認する。
確認後は dispatch を削除して通常運用（pull_request 発火）のみに戻す。

## 変更点
- `.github/workflows/diag_required_vs_reported.yml`
  - `workflow_dispatch` を追加（入力: pr_number）
  - イベント種別に応じて **PR番号 / HEAD SHA** を解決するステップを追加
  - 既存ロジック（PyYAMLで required 取得 / check-runs 取得 / upsert コメント）はそのまま活用
- 追加のみ。既存CIや運用の挙動は変更しない（Gate化なし）

context_header: repo=vpm-mini / branch=main / phase=Phase 2

## Exit Criteria（このPRのDoD）
- [ ] Actions で **Run workflow** が有効になっている（diag-required-vs-reported）
- [ ] `pr_number=314` で手動実行が成功する（※実行はマージ後に実施）
- [ ] CI Green（既存の必須チェックに影響なし）
- [ ] 変更は上記ファイルのみ（追加・軽微修正で既存運用に非影響）

## After Merge（運用メモ）
1) Actions → diag-required-vs-reported → **Run workflow**  
   Branch: `main` / `pr_number=314` を入力して実行  
2) #314 の Conversation に `### Diag: required vs reported` が **1件** 出れば成功  
3) 別PRで `workflow_dispatch` を削除して元に戻す（pull_request のみ）

## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

