### PR TITLE
fix(diag): correct yaml indentation for workflow

### DIFF
--- a/.github/workflows/diag_required_vs_reported.yml
+++ b/.github/workflows/diag_required_vs_reported.yml
@@ -56,11 +56,11 @@ jobs:
         shell: bash
         run: |
           python - <<'PY' > required.json
-import json, pathlib, yaml
-cfg = yaml.safe_load(pathlib.Path("config/understanding.yaml").read_text(encoding="utf-8")) or {}
-lst = cfg.get("ruleset_required", []) or []
-req = sorted({str(x).strip() for x in lst if str(x).strip()})
-print(json.dumps(req, ensure_ascii=False))
+          import json, pathlib, yaml
+          cfg = yaml.safe_load(pathlib.Path("config/understanding.yaml").read_text(encoding="utf-8")) or {}
+          lst = cfg.get("ruleset_required", []) or []
+          req = sorted({str(x).strip() for x in lst if str(x).strip()})
+          print(json.dumps(req, ensure_ascii=False))
 PY
           echo "required=$(cat required.json)" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Fix PyYAML heredoc indentation so diag workflow parses as valid YAML.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

