### PR TITLE
chore(ci): skip Buildx on pull_request (avoid runner hang)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,10 @@ jobs:
           python-version: '3.11'
       - name: Install curl & jq
         run: sudo apt-get update && sudo apt-get install -y curl jq
-      - name: Set up Docker Buildx
+      - name: Set up Docker Buildx (push only)
+        if: github.event_name == 'push'
         uses: docker/setup-buildx-action@v3
+        timeout-minutes: 5
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
- PR 検証では Buildx をスキップし、push のみ実行に限定します。\n- 追加で timeout を 5 分に設定し、push 時にハングしても早期終了します。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

