### PR TITLE
chore(ci): limit push workflows to main

### DIFF
--- a/.github/workflows/build_.yml
+++ b/.github/workflows/build_.yml
@@ -1,11 +1,16 @@
 name: build_
+
 on:
   push:
+    branches:
+      - main
     paths:
       - "services//**"
       - ".github/workflows/build_.yml"
+
 jobs:
   build:
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -13,7 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        timeout-minutes: 5
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/cd_canary.yml
+++ b/.github/workflows/cd_canary.yml
@@ -2,6 +2,8 @@ name: CD Canary Pipeline
 
 on:
   push:
+    branches:
+      - main
     paths:
       - "infra/gitops/apps/hello/**"
       - "infra/gitops/apps/hello-v2/**"
@@ -22,6 +24,7 @@ env:
 
 jobs:
   canary:
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: self-hosted
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
- build_/cd_canary を main ブランチの push のみに限定しました。\n- PR ブランチでは Buildx や CD Canary が走らず、runner ハングによる必須チェック失敗を防ぎます。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

