### PR TITLE
chore(ci): limit CD Canary (multi-cluster) to main push only

### DIFF
--- a/.github/workflows/cd_canary_multicluster.yml
+++ b/.github/workflows/cd_canary_multicluster.yml
@@ -2,6 +2,10 @@ name: CD Canary (Multi-Cluster)
 
 on:
   push:
+    branches:
+      - main
+    tags-ignore:
+      - '*'
     paths:
       - 'hello/**'
       - 'infra/k8s/**/hello-ksvc.yaml'
@@ -28,6 +32,7 @@ env:
 
 jobs:
   cd:
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/STATE/current_state.md
+++ b/STATE/current_state.md
@@ -21,7 +21,7 @@ active_repo: vpm-mini
 active_branch: main
 phase: Phase 2
 context_header: repo=vpm-mini / branch=main / phase=Phase 2 Trial
-short_goal: "P2-4 達成（hello を Knative Service へ移植／READY=True）"
+short_goal: "P2-5（Autoscale PoC：min=0 / max=30 の挙動を記録）"
 phase_notes: Chaos Engineering focus — dev monitoring line & understanding diag
 
 ## Phase Progress
@@ -67,3 +67,7 @@ Updated: 2025-09-16T20:23:15Z
 
 ### Audit Links (P2-3)
 - Evidence: reports/evidence_p2-3_dev_monitoring_20251001T174411Z.md
+
+
+### Audit Links (P2-4)
+- Evidence: reports/evidence_p2-4_hello_20251001T211112Z.md

--- a/config/understanding.yaml
+++ b/config/understanding.yaml
@@ -8,6 +8,6 @@ ruleset_required:
 - evidence-dod
 branch_required: []
 goals:
-  short: P2-4（hello を Knative Service へ移植／READY=True）
+  short: P2-5（Autoscale PoC：min=0 / max=30 の挙動を記録）
   mid: サービス移植 / Autoscale PoC
   long: 小規模Swarm安定 + KPI閾値達成


### PR DESCRIPTION
タグや PR ブランチでは multi-cluster Canary を実行しないようにし、jobs にも条件を付けました。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

