### PR TITLE
feat(p2-6b): add real ServiceMonitor/PrometheusRule (k8s-validate green + evidence)

### DIFF
--- a/infra/k8s/overlays/dev/monitoring/kustomization.yaml
+++ b/infra/k8s/overlays/dev/monitoring/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespace.yaml
-  - servicemonitor.yaml
-  - promrule.yaml
+- namespace.yaml
+- promrule-hello.yaml
+- promrule.yaml
+- servicemonitor-hello.yaml
+- servicemonitor.yaml

--- a/infra/k8s/overlays/dev/monitoring/promrule-hello.yaml
+++ b/infra/k8s/overlays/dev/monitoring/promrule-hello.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: hello-rules
+  namespace: monitoring-dev
+spec:
+  groups:
+    - name: hello
+      rules:
+        - alert: HelloTargetMissing
+          expr: absent(up{job="hello"}) == 1
+          for: 1m
+          labels: { severity: warning }
+          annotations:
+            summary: "hello target missing"

--- a/infra/k8s/overlays/dev/monitoring/servicemonitor-hello.yaml
+++ b/infra/k8s/overlays/dev/monitoring/servicemonitor-hello.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: hello-sm
+  namespace: monitoring-dev
+spec:
+  namespaceSelector:
+    matchNames: ["default"]
+  selector:
+    matchLabels:
+      app: hello
+  endpoints:
+    - port: http
+      interval: 30s

--- a/reports/evidence_p2-6b_monitoring_real_20251003T163437Z.md
+++ b/reports/evidence_p2-6b_monitoring_real_20251003T163437Z.md
@@ -1,0 +1,6 @@
+Purpose: add real ServiceMonitor/PromRule for hello (syntax OK)
+Files:
+- monitoring/servicemonitor-hello.yaml
+- monitoring/promrule-hello.yaml
+Run URL:
+Notes: selector app=hello, namespace=default, port=http

--- a/reports/evidence_p2-6b_monitoring_real_20251003T163437Z.md
+++ b/reports/evidence_p2-6b_monitoring_real_20251003T163437Z.md
@@ -3,4 +3,4 @@ Files:
 - monitoring/servicemonitor-hello.yaml
 - monitoring/promrule-hello.yaml
 Run URL:
-https://github.com/HirakuArai/vpm-mini/actions/runs/18228494358/job/51905796639
+https://github.com/HirakuArai/vpm-mini/actions/runs/18228559023/job/51906023605

--- a/reports/evidence_p2-6b_monitoring_real_20251003T163437Z.md
+++ b/reports/evidence_p2-6b_monitoring_real_20251003T163437Z.md
@@ -3,4 +3,4 @@ Files:
 - monitoring/servicemonitor-hello.yaml
 - monitoring/promrule-hello.yaml
 Run URL:
-Notes: selector app=hello, namespace=default, port=http
+https://github.com/HirakuArai/vpm-mini/actions/runs/18228153645/job/51904638296

--- a/reports/evidence_p2-6b_monitoring_real_20251003T163437Z.md
+++ b/reports/evidence_p2-6b_monitoring_real_20251003T163437Z.md
@@ -3,4 +3,4 @@ Files:
 - monitoring/servicemonitor-hello.yaml
 - monitoring/promrule-hello.yaml
 Run URL:
-https://github.com/HirakuArai/vpm-mini/actions/runs/18228153645/job/51904638296
+https://github.com/HirakuArai/vpm-mini/actions/runs/18228415846/job/51905528100

--- a/reports/evidence_p2-6b_monitoring_real_20251003T163437Z.md
+++ b/reports/evidence_p2-6b_monitoring_real_20251003T163437Z.md
@@ -3,4 +3,4 @@ Files:
 - monitoring/servicemonitor-hello.yaml
 - monitoring/promrule-hello.yaml
 Run URL:
-https://github.com/HirakuArai/vpm-mini/actions/runs/18228415846/job/51905528100
+https://github.com/HirakuArai/vpm-mini/actions/runs/18228494358/job/51905796639


### PR DESCRIPTION
dev監視ラインに実体のServiceMonitor/PromRuleを追加。k8s-validate Green後にRun URLをEvidenceへ追記します。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/evidence_p2-6b_monitoring_real_20251003T163437Z.md

- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/evidence_p2-6b_monitoring_real_20251003T163437Z.md

- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/evidence_p2-6b_monitoring_real_20251003T163437Z.md

- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/evidence_p2-6b_monitoring_real_20251003T163437Z.md

- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/evidence_p2-6b_monitoring_real_20251003T163437Z.md

