### PR TITLE
feat(p3-1): guardrails lite (actionlint + diag warn-label)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,20 @@
+name: actionlint
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+permissions:
+  contents: read
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download actionlint
+        run: |
+          set -euo pipefail
+          curl -sS https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- -b .
+          ./actionlint --version
+      - name: Run actionlint
+        run: ./actionlint -color

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -18,3 +18,4 @@ jobs:
           ./actionlint --version
       - name: Run actionlint
         run: ./actionlint -color
+        continue-on-error: true

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Download actionlint
         run: |
           set -euo pipefail
-          curl -sS https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- -b .
+          curl -sS https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s --
           ./actionlint --version
       - name: Run actionlint
         run: ./actionlint -color

--- a/.github/workflows/diag_required_vs_reported.yml
+++ b/.github/workflows/diag_required_vs_reported.yml
@@ -94,3 +94,18 @@ jobs:
           else
             gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments -f body="$BODY" >/dev/null
           fi
+      - name: Label for diag missing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          COUNT=$(jq -r '.missing|length' diff.json 2>/dev/null || echo 0)
+          gh label create needs-sync --color FF8C00 --description "Diag required vs reported mismatch" >/dev/null 2>&1 || true
+          if [ "${COUNT}" -gt 0 ]; then
+            gh pr edit "${PR_NUMBER}" --add-label "needs-sync" >/dev/null 2>&1 || true
+          else
+            gh pr edit "${PR_NUMBER}" --remove-label "needs-sync" >/dev/null 2>&1 || true
+          fi
+

--- a/reports/evidence_p3_1_guardrails_lite_20251003T172358Z.md
+++ b/reports/evidence_p3_1_guardrails_lite_20251003T172358Z.md
@@ -3,5 +3,5 @@ Checks:
 - actionlint (PR only)
 - diag warn-label when missing>0
 Run URLs:
-- actionlint: https://github.com/HirakuArai/vpm-mini/actions/runs/18230089397/job/51911126497
+- actionlint: https://github.com/HirakuArai/vpm-mini/actions/runs/18230369884/job/51912036921
 Notes: non-blocking (warn only)

--- a/reports/evidence_p3_1_guardrails_lite_20251003T172358Z.md
+++ b/reports/evidence_p3_1_guardrails_lite_20251003T172358Z.md
@@ -4,5 +4,5 @@ Checks:
 - diag warn-label when missing>0
 Run URLs:
 - actionlint: 
-- PR example: 
+https://github.com/HirakuArai/vpm-mini/actions/runs/18229853068/job/51910300989
 Notes: non-blocking (warn only)

--- a/reports/evidence_p3_1_guardrails_lite_20251003T172358Z.md
+++ b/reports/evidence_p3_1_guardrails_lite_20251003T172358Z.md
@@ -1,0 +1,8 @@
+Purpose: Guardrails lite (actionlint + diag warn-label)
+Checks:
+- actionlint (PR only)
+- diag warn-label when missing>0
+Run URLs:
+- actionlint: 
+- PR example: 
+Notes: non-blocking (warn only)

--- a/reports/evidence_p3_1_guardrails_lite_20251003T172358Z.md
+++ b/reports/evidence_p3_1_guardrails_lite_20251003T172358Z.md
@@ -3,6 +3,5 @@ Checks:
 - actionlint (PR only)
 - diag warn-label when missing>0
 Run URLs:
-- actionlint: 
-https://github.com/HirakuArai/vpm-mini/actions/runs/18229853068/job/51910300989
+- actionlint: https://github.com/HirakuArai/vpm-mini/actions/runs/18230089397/job/51911126497
 Notes: non-blocking (warn only)


### PR DESCRIPTION
actionlintを追加、diagにmissing>0時のwarnラベル(needs-sync)付与/0で削除を追加。非ブロッキング。EvidenceにRun URLを追記します。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/evidence_p3_1_guardrails_lite_20251003T172358Z.md

- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/evidence_p3_1_guardrails_lite_20251003T172358Z.md

- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/evidence_p3_1_guardrails_lite_20251003T172358Z.md

- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/evidence_p3_1_guardrails_lite_20251003T172358Z.md

- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/evidence_p3_1_guardrails_lite_20251003T172358Z.md

- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/evidence_p3_1_guardrails_lite_20251003T172358Z.md

