### PR TITLE
docs(p3-3): Exit report + STATE→P3-4; README追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,8 @@ make trial-daily
 ### Understanding Guard (post)
 - 既存guardは保持。本workflowはPR上のコメント/ラベル/Evidence整形のみ（非ブロッキング）
 - GH_TOKEN を明示し、PR文脈が無いときは動作をスキップ
+
+### P3-3 Exit (non-blocking guard stabilized)
+- 🧭 一意コメント＋warnラベル＋Evidence生成（post）
+- legacy guard は continue-on-error で非ブロッキング運用
+- 詳細: reports/p3_3_exit_20251004T001113Z.md

--- a/STATE/current_state.md
+++ b/STATE/current_state.md
@@ -64,18 +64,15 @@ phase_notes: Chaos Engineering focus — dev monitoring line & understanding dia
 
 Updated: 2025-09-16T20:23:15Z
 
-
 ### Audit Links (P2-3)
 - Evidence: reports/evidence_p2-3_dev_monitoring_20251001T174411Z.md
-
 
 ### Audit Links (P2-4)
 - Evidence: reports/evidence_p2-4_hello_20251001T211112Z.md
 
-
 ### Audit Links (P2-5)
 - Evidence: (missing)
 
-
 ### Audit Links (P2-6b)
 - Evidence: reports/evidence_p2-6b_monitoring_real_20251003T163437Z.md
+

--- a/reports/p3_3_exit_20251004T001113Z.md
+++ b/reports/p3_3_exit_20251004T001113Z.md
@@ -1,0 +1,15 @@
+# P3-3 Exit Report — understanding-guard non-blocking stabilized
+
+## Outcomes
+- Legacy guard: **non-blocking**（continue-on-error）を維持
+- Post workflow: 🧭 **一意コメント**＋ **warnラベル**＋ **Evidence** 生成を安定稼働
+- Local/CI 判定の一致: \SUMMARY: snapshot=success; diag_missing=none; goals_equal=yes → goals_equal=yes
+
+## Merged PRs
+- #338 chore(p3-3): legacy guard non-blocking
+- #336 feat(p3-3): add understanding-guard post workflow (non-blocking)
+
+## Evidence
+- Latest post run: https://github.com/HirakuArai/vpm-mini/actions/runs/18236422262
+- Latest guard run: https://github.com/HirakuArai/vpm-mini/actions/runs/18236422241
+- Evidence file: reports/evidence_p3_3_understanding_guard_20251003T195450Z.md


### PR DESCRIPTION
P3-3 Exit を正式化し、P3-4の短期ゴールをSTATEに反映します。

- Exitレポ: `reports/p3_3_exit_*.md`
- タグ: `p3-3-complete_*`
- STATE: `short_goal` → **P3-4（understanding-guard: required化A/Bの設計＋dry-run、post維持）**
- README: P3-3 Exit 追記

マージ後のOKサイン:


python tools/understanding_status.py --format summary

期待: SUMMARY: snapshot=success; diag_missing=none; goals_equal=yes

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/p3_3_exit_20251004T001113Z.md

