### PR TITLE
fix(p3-4): ready-for-required when counts >=1

### DIFF
--- a/.github/workflows/understanding_guard_post.yml
+++ b/.github/workflows/understanding_guard_post.yml
@@ -98,7 +98,7 @@ jobs:
           DG=${{ steps.dry.outputs.dry_guard }}
           DS=${{ steps.dry.outputs.dry_snap }}
           DG2=${{ steps.dry.outputs.dry_goal }}
-          if [ "$DG" = "1" ] && [ "$DS" = "1" ] && [ "$DG2" = "1" ]; then
+          if [ "${DG:-0}" -ge 1 ] && [ "${DS:-0}" -ge 1 ] && [ "${DG2:-0}" -ge 1 ]; then
             gh pr edit "$PRNUM" --add-label ready-for-required >/dev/null || true
           else
             gh pr edit "$PRNUM" --remove-label ready-for-required >/dev/null || true


### PR DESCRIPTION
Label ready-for-required if each dry-run context count is >=1 (reruns safe).

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

