### PR TITLE
chore(reports): p2-observability bootstrap

### DIFF
--- a/reports/p2_obs_bootstrap_20251012_084708.md
+++ b/reports/p2_obs_bootstrap_20251012_084708.md
@@ -1,0 +1,23 @@
+# p2-obs bootstrap (20251012_084708)
+```
+## Pods
+NAME                                                              READY   STATUS    RESTARTS   AGE
+alertmanager-vpm-mini-kube-prometheus-s-alertmanager-0            2/2     Running   0          91s
+prometheus-vpm-mini-kube-prometheus-s-prometheus-0                2/2     Running   0          91s
+vpm-mini-kube-prometheus-s-operator-9774cdc4f-qp8j8               1/1     Running   0          110s
+vpm-mini-kube-prometheus-stack-grafana-65b496dbc8-csgj7           3/3     Running   0          110s
+vpm-mini-kube-prometheus-stack-kube-state-metrics-cd994d7dmz2q5   1/1     Running   0          110s
+vpm-mini-kube-prometheus-stack-prometheus-node-exporter-pt9c5     1/1     Running   0          110s
+
+## Services
+NAME                                                      TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                      AGE
+alertmanager-operated                                     ClusterIP   None            <none>        9093/TCP,9094/TCP,9094/UDP   91s
+prometheus-operated                                       ClusterIP   None            <none>        9090/TCP                     91s
+vpm-mini-kube-prometheus-s-alertmanager                   ClusterIP   10.96.64.215    <none>        9093/TCP,8080/TCP            110s
+vpm-mini-kube-prometheus-s-operator                       ClusterIP   10.96.3.42      <none>        443/TCP                      110s
+vpm-mini-kube-prometheus-s-prometheus                     ClusterIP   10.96.210.34    <none>        9090/TCP,8080/TCP            110s
+vpm-mini-kube-prometheus-stack-grafana                    ClusterIP   10.96.217.87    <none>        80/TCP                       110s
+vpm-mini-kube-prometheus-stack-kube-state-metrics         ClusterIP   10.96.24.203    <none>        8080/TCP                     110s
+vpm-mini-kube-prometheus-stack-prometheus-node-exporter   ClusterIP   10.96.210.153   <none>        9100/TCP                     110s
+```
+✅ P2-OBS GREEN (kube-prometheus-stack running)


### PR DESCRIPTION
Add evidence for kube-prometheus-stack running.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/p2_obs_bootstrap_20251012_084708.md

