### PR TITLE
chore(observability): PodMonitor template for KService

### DIFF
--- a/docs/observability/ksvc_metrics.md
+++ b/docs/observability/ksvc_metrics.md
@@ -1,0 +1,12 @@
+# KService メトリクス収集テンプレ
+
+## 使い方
+1. `infra/observability/podmonitor-ksvc.yaml` の `<SERVICE>` と `<NAMESPACE>` を置換して適用。
+2. kube-prometheus-stack（release=kps）が `monitoring` NS にあることを確認。
+3. `up{namespace="<NAMESPACE>",pod=~"<SERVICE>-.*"}` が `1` になること。
+4. Grafana で RPS 等（実在名に合わせる）を1枚パネル化。
+
+## DoD
+- Prometheus targets: UP
+- `up{…}` = 1
+- Grafana: UP or RPS のパネル1枚

--- a/infra/observability/podmonitor-ksvc.yaml
+++ b/infra/observability/podmonitor-ksvc.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ksvc-<SERVICE>-queue-proxy
+  namespace: monitoring
+  labels: { release: kps }
+spec:
+  namespaceSelector:
+    matchNames: ["<NAMESPACE>"]   # 例: default
+  selector:
+    matchLabels:
+      serving.knative.dev/service: "<SERVICE>"   # 例: hello
+  podMetricsEndpoints:
+  - port: http-autometric   # 9090
+    path: /metrics
+    interval: 15s
+    scrapeTimeout: 10s
+    enableHttp2: false
+  - port: http-usermetric   # 9091
+    path: /metrics
+    interval: 15s
+    scrapeTimeout: 10s
+    enableHttp2: false


### PR DESCRIPTION
将来のKServiceへ再利用可能な観測テンプレを追加

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

