### PR TITLE
governance: unified VPM entrypoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,3 +95,10 @@ state-view:
 
 phase-guard:
 	PHASE_ALLOWED="Phase 2" $(PYTHON) scripts/phase_guard.py --project $(PROJECT)
+
+vpm-decide:
+	@TS=$$(date +%Y%m%d_%H%M%S); IN=.vpm/intent_input_$${TS}.md; OUT=.vpm/intent_output_$${TS}.md; \
+	mkdir -p .vpm; \
+	[ -f $$IN ] || echo "# VPM Intent Input" > $$IN; \
+	scripts/vpm --mode decide --in $$IN --out $$OUT; \
+	echo "Wrote $$OUT"

--- a/docs/governance/vpm_entrypoint.md
+++ b/docs/governance/vpm_entrypoint.md
@@ -1,0 +1,8 @@
+# VPM Entry Point (unified)
+- **CLI**: `scripts/vpm --mode decide --in <input.md> --out <output.md>`
+- **Resolution**:
+  1) If `scripts/codex_shim.py` exists → delegate
+  2) Else if `scripts/vpm_engine.py` exists → delegate
+  3) Else → stub fallback (雛形の推奨を出力)
+- **I/O**: 作業I/Oは `.vpm/` に置き、Gitには載せない（ローカル専用）
+- **今後**: `scripts/vpm_engine.py` を実装すれば差し替え可能（スイッチ不要）

--- a/scripts/vpm
+++ b/scripts/vpm
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# 統一インターフェース：
+#   scripts/vpm --mode decide --in <input.md> --out <output.md>
+MODE=""; IN=""; OUT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --mode) MODE="$2"; shift 2;;
+    --in)   IN="$2";   shift 2;;
+    --out)  OUT="$2";  shift 2;;
+    *) echo "unknown arg: $1" >&2; exit 2;;
+  esac
+done
+[ -n "${MODE:-}" ] && [ -n "${IN:-}" ] && [ -n "${OUT:-}" ] || { echo "usage: scripts/vpm --mode decide --in <in> --out <out>"; exit 2; }
+
+# 1) 既存エンジンがあれば優先して呼ぶ（軽い検出）
+if [ -f scripts/codex_shim.py ]; then
+  # 例: 既存のLLMシムに渡す（無ければフォールバック）
+  python3 scripts/codex_shim.py --mode "${MODE}" --in "${IN}" --out "${OUT}" 2>/dev/null && exit 0 || true
+fi
+if command -v python3 >/dev/null && [ -f scripts/vpm_engine.py ]; then
+  python3 scripts/vpm_engine.py --mode "${MODE}" --in "${IN}" --out "${OUT}" && exit 0 || true
+fi
+
+# 2) フォールバック（最小スタブ）：入力を読み、雛形の意思決定を吐く
+mkdir -p "$(dirname "${OUT}")"
+{
+  echo "# VPM Output (stub)"
+  echo "mode: ${MODE}"
+  echo
+  echo "## read-facts"
+  [ -f "${IN}" ] && sed -n '1,80p' "${IN}" || echo "(no input file)"
+  echo
+  echo "## options"
+  echo "- A) 最小リスク（stateless/HTTP）"
+  echo "- B) 中庸（軽い依存あり）"
+  echo "- C) 高リスク（stateful/依存重）"
+  echo
+  echo "## recommendation"
+  echo "A を推奨（Phase 2の速度と安全性の観点）"
+} > "${OUT}"

--- a/scripts/vpm_engine.py
+++ b/scripts/vpm_engine.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import argparse
+import pathlib
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", required=True)
+    parser.add_argument("--in", dest="input_path", required=True)
+    parser.add_argument("--out", dest="output_path", required=True)
+    args = parser.parse_args()
+
+    out_path = pathlib.Path(args.output_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        "# VPM Output (engine stub)\n"
+        f"mode: {args.mode}\n\n"
+        f"(read {args.input_path})\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
標準CLIを確立。.vpm はローカルI/Oとして無視。将来は vpm_engine.py に差し替えればOK。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

