### PR TITLE
feat(p2-3): rougel-exporter KService

### DIFF
--- a/infra/k8s/overlays/dev/rougel-exporter-ksvc.yaml
+++ b/infra/k8s/overlays/dev/rougel-exporter-ksvc.yaml
@@ -1,0 +1,28 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: rougel-exporter
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "1"
+    spec:
+      containers:
+      - name: app
+        image: gcr.io/knative-samples/helloworld-go
+        env:
+        - name: TARGET
+          value: rougel-exporter
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 2
+          periodSeconds: 5
+      enableServiceLinks: false
+      timeoutSeconds: 300

--- a/reports/p2_3_rougel-exporter_deploy_20251013_071442.md
+++ b/reports/p2_3_rougel-exporter_deploy_20251013_071442.md
@@ -1,0 +1,9 @@
+# P2-3 Evidence: rougel-exporter KService
+- READY: True
+- URL: http://rougel-exporter.default.127.0.0.1.sslip.io
+```
+
+NAME                                                READY   STATUS    RESTARTS   AGE    IP            NODE                     NOMINATED NODE   READINESS GATES
+rougel-exporter-00003-deployment-676fc8d966-gx8jr   2/2     Running   0          114s   10.244.0.59   vpm-mini-control-plane   <none>           <none>
+```
+


### PR DESCRIPTION
DoD: READY=True; internal curl OK; evidence included.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/p2_3_rougel-exporter_deploy_20251013_071442.md

