### PR TITLE
ci: GHCR publish workflow (rougel-exporter)

### DIFF
--- a/.github/workflows/publish-rougel-exporter.yml
+++ b/.github/workflows/publish-rougel-exporter.yml
@@ -1,0 +1,24 @@
+name: Publish rougel-exporter
+on:
+  workflow_dispatch:
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/rougel-exporter:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Actionsで正式にビルド/公開。最小Dockerfileは後で本物に差し替え。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

