### PR TITLE
ci: lowercase owner for GHCR publish

### DIFF
--- a/.github/workflows/publish-rougel-exporter.yml
+++ b/.github/workflows/publish-rougel-exporter.yml
@@ -15,10 +15,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Derive lowercase owner
+        id: meta
+        run: echo "owner=$(echo \"${GITHUB_REPOSITORY_OWNER}\" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
       - uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/rougel-exporter:latest
+          tags: ghcr.io/${{ steps.meta.outputs.owner }}/rougel-exporter:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
GHCR requires repo names to be lowercase.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

