### PR TITLE
ci: multi-arch publish (rougel-exporter)

### DIFF
--- a/.github/workflows/publish-rougel-exporter.yml
+++ b/.github/workflows/publish-rougel-exporter.yml
@@ -9,19 +9,19 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Derive lowercase owner
-        id: meta
-        run: echo "owner=$(echo ${GITHUB_REPOSITORY_OWNER} | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
       - uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ steps.meta.outputs.owner }}/rougel-exporter:latest
+          tags: ghcr.io/${{ github.repository_owner }}/rougel-exporter:latest
+          platforms: linux/amd64,linux/arm64
+          provenance: false
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Fix ImagePullBackOff: add linux/amd64 manifest.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

