### PR TITLE
ci: lowercase owner step for multi-arch publish

### DIFF
--- a/.github/workflows/publish-rougel-exporter.yml
+++ b/.github/workflows/publish-rougel-exporter.yml
@@ -16,11 +16,14 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Derive lowercase owner
+        id: meta
+        run: echo "owner=$(echo ${GITHUB_REPOSITORY_OWNER} | tr [:upper:] [:lower:])" >> "$GITHUB_OUTPUT"
       - uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/rougel-exporter:latest
+          tags: ghcr.io/${{ steps.meta.outputs.owner }}/rougel-exporter:latest
           platforms: linux/amd64,linux/arm64
           provenance: false
           cache-from: type=gha


### PR DESCRIPTION
Ensure GHCR tag uses lowercase owner after multi-arch change.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

