### PR TITLE
obs: persist PodMonitor for hello (9091)

### DIFF
--- a/infra/observability/podmonitor-hello-9091.yaml
+++ b/infra/observability/podmonitor-hello-9091.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ksvc-hello-queue-proxy-9091
+  namespace: monitoring
+  labels:
+    release: kps
+spec:
+  namespaceSelector:
+    matchNames: ["default"]
+  selector:
+    matchLabels:
+      serving.knative.dev/service: "hello"
+  podMetricsEndpoints:
+  - port: http-usermetric
+    path: /metrics
+    interval: 15s
+    scrapeTimeout: 10s
+    enableHttp2: false


### PR DESCRIPTION
UP=1 を確認済みの設定を恒久化。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

