### PR TITLE
feat(p4-1): hello KService READY=True (evidence included)

### DIFF
--- a/infra/k8s/overlays/dev/hello-ksvc.yaml
+++ b/infra/k8s/overlays/dev/hello-ksvc.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: default
 spec:
   template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "1"
     spec:
       containers:
         - image: gcr.io/knative-samples/helloworld-go

--- a/reports/p4_1_hello_ksvc_20251017_050955.md
+++ b/reports/p4_1_hello_ksvc_20251017_050955.md
@@ -1,0 +1,20 @@
+# P4-1 hello KService check (20251017_050955)
+
+URL: http://hello.default.127.0.0.1.sslip.io
+
+```bash
+kubectl get ksvc hello -o wide
+NAME    URL                                       LATESTCREATED   LATESTREADY   READY   REASON
+hello   http://hello.default.127.0.0.1.sslip.io   hello-00003     hello-00003   True    
+```
+
+```http
+HTTP/1.1 200 OK
+content-length: 16
+content-type: text/plain; charset=utf-8
+date: Thu, 16 Oct 2025 20:09:28 GMT
+x-envoy-upstream-service-time: 8
+server: envoy
+
+Hello vpm-mini!
+```


### PR DESCRIPTION
Knative最小縦スライス。READY=TrueとHTTP疎通のEvidenceを同梱。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/p4_1_hello_ksvc_20251017_050955.md

- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
- reports/p4_1_hello_ksvc_20251017_050955.md



Closes #402
