### PR TITLE
chore(dev): Kourier access helpers & Makefile targets

### DIFF
--- a/Makefile.kourier
+++ b/Makefile.kourier
@@ -1,0 +1,12 @@
+.PHONY: pf-kourier curl-hello curl-hello-pf
+
+pf-kourier:
+	@scripts/pf_kourier.sh
+
+# NodePort 優先で hello へ HTTP 確認（1 行だけ表示）
+curl-hello:
+	@scripts/test_hello.sh
+
+# 強制的に port-forward 経由でテスト
+curl-hello-pf:
+	@FORCE_PF=1 scripts/test_hello.sh

--- a/README.md
+++ b/README.md
@@ -95,3 +95,11 @@ make trial-daily
 - Add dry-run workflow to emit success statuses for future required checks:
   - understanding/guard-required, understanding/snapshot-present, understanding/goals-synced
 - No rule change yet; observe impact while keeping post workflow.
+
+## Kourier Access (dev)
+
+```bash
+make -f Makefile.kourier curl-hello      # NodePort優先でHTTP 200確認
+make -f Makefile.kourier pf-kourier      # 8080:8080 port-forwardを起動（別ターミナルで curl-hello-pf）
+make -f Makefile.kourier curl-hello-pf   # 強制的にpf経由でHTTP 200確認
+```

--- a/scripts/pf_kourier.sh
+++ b/scripts/pf_kourier.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS=${NS:-kourier-system}
+echo "Port-forwarding 3scale-kourier-gateway (8080:8080) in namespace=${NS}"
+kubectl -n "${NS}" port-forward deploy/3scale-kourier-gateway 8080:8080

--- a/scripts/test_hello.sh
+++ b/scripts/test_hello.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NS=${NS:-kourier-system}
+FORCE_PF=${FORCE_PF:-0}
+URL="$(kubectl get ksvc hello -o jsonpath='{.status.url}')"
+HOST="${URL#http://}"
+HOST="${HOST#https://}"
+
+NP_HTTP="$(kubectl -n "${NS}" get svc kourier -o jsonpath='{range .spec.ports[*]}{.name}:{.port}:{.nodePort}->{.targetPort}{"\n"}{end}' \
+  | awk -F ':' '/^http/ {node=$3; sub(/->.*/, "", node); if (node ~ /^[0-9]+$/) {print node; exit}}')"
+
+if [[ "${FORCE_PF}" != "1" && -n "${NP_HTTP}" ]]; then
+  echo "== via NodePort :${NP_HTTP}"
+  set +e
+  LINE="$(curl -i -sS -H "Host: ${HOST}" "http://127.0.0.1:${NP_HTTP}/" 2>/dev/null | head -n 1)"
+  RC=$?
+  set -e
+  printf "%s\n" "${LINE}"
+  if [[ ${RC} -eq 0 ]]; then
+    exit 0
+  fi
+  echo "NodePort access failed, falling back to port-forward"
+fi
+
+echo "== via port-forward 8080:8080"
+kubectl -n "${NS}" port-forward deploy/3scale-kourier-gateway 8080:8080 >/tmp/kourier_pf.log 2>&1 &
+PF=$!
+trap 'kill ${PF} 2>/dev/null || true' EXIT
+sleep 2
+curl -i -sS -H "Host: ${HOST}" "http://127.0.0.1:8080/" | head -n 1


### PR DESCRIPTION
NodePort/port-forward のどちらでも hello のHTTP疎通を安定確認できる開発用ヘルパーを追加。README追補。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

