### PR TITLE
feat(p4-2): Grafana panel for blackbox uptime

### DIFF
--- a/infra/grafana/dashboards/p4_blackbox_uptime.json
+++ b/infra/grafana/dashboards/p4_blackbox_uptime.json
@@ -1,0 +1,34 @@
+{
+  "title": "P4-2 Uptime (blackbox)",
+  "uid": "p4-uptime-blackbox",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "probe_success (http_2xx_host)",
+      "datasource": {"type": "prometheus", "uid": "Prometheus"},
+      "targets": [
+        {"expr": "avg(probe_success{module=\"http_2xx_host\"})"}
+      ],
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}}
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP Status Code",
+      "datasource": {"type": "prometheus", "uid": "Prometheus"},
+      "targets": [
+        {"expr": "avg_over_time(probe_http_status_code{module=\"http_2xx_host\"}[5m])"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Probe Duration (s)",
+      "datasource": {"type": "prometheus", "uid": "Prometheus"},
+      "targets": [
+        {"expr": "probe_duration_seconds{module=\"http_2xx_host\"}"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
probe_success / status / duration を可視化する最小ダッシュボードを追加。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

