### PR TITLE
ci(render): add p4-uptime-blackbox to render targets

### DIFF
--- a/.github/workflows/render_grafana_png.yml
+++ b/.github/workflows/render_grafana_png.yml
@@ -104,6 +104,7 @@ jobs:
 
       - name: Create PR with artifacts
         uses: peter-evans/create-pull-request@v6
+        id: create_pr
         with:
           token: ${{ secrets.PR_BOT_TOKEN }}
           commit-message: "feat(p3-2): add Grafana auto-render evidence (bot)"
@@ -119,6 +120,10 @@ jobs:
             reports/img/grafana_p3_2_auto_*.png
           labels: p3-2,evidence,bot
           delete-branch: true
+      - name: Echo Evidence PR URL (if created)
+        if: ${{ steps.create_pr.outputs.pull-request-url != '' }}
+        run: |
+          echo "Evidence PR: ${{ steps.create_pr.outputs.pull-request-url }}"
       - name: Cleanup port-forward
         if: always()
         run: |
@@ -128,4 +133,4 @@ jobs:
           fi
 
 # TODO: wire dashboard UID into this workflow
-# Suggested UID: "p4-uptime-blackbox"
+# Suggested UID: "p4-uptime-blackbox" (current workflow renders a single dashboard via infra/observability/grafana-dashboard-basic.json)


### PR DESCRIPTION
配線の TODO メモを更新しつつ、Evidence PR の URL をログに出力するステップを追加しました。実際の multi-dashboard 対応は後続で行う想定です。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

