### PR TITLE
ci(render): refresh dispatch indexing

### DIFF
--- a/.github/workflows/render_grafana_png.yml
+++ b/.github/workflows/render_grafana_png.yml
@@ -188,3 +188,5 @@ jobs:
 
 # TODO: wire dashboard UID into this workflow
 # Suggested UID: "p4-uptime-blackbox" (current workflow renders a single dashboard via infra/observability/grafana-dashboard-basic.json)
+
+# dispatch-refresh: 2025-10-17T20:47:18Z


### PR DESCRIPTION
Force re-index of workflow_dispatch by touching the workflow.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

