### PR TITLE
ci(render): add repository_dispatch trigger

### DIFF
--- a/.github/workflows/render_grafana_png.yml
+++ b/.github/workflows/render_grafana_png.yml
@@ -1,6 +1,8 @@
 name: render-grafana-png
 on:
-  schedule:
+  
+  repository_dispatch:
+    types: [render_now]schedule:
     - cron: "0 0 * * *"  # 09:00 JST (UTC 00:00)
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
workflow_dispatch の再インデックス待ちを回避するため、暫定で repository_dispatch(types: render_now) を追加。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

