### PR TITLE
ci(render): fix repository_dispatch indentation

### DIFF
--- a/.github/workflows/render_grafana_png.yml
+++ b/.github/workflows/render_grafana_png.yml
@@ -1,8 +1,8 @@
 name: render-grafana-png
 on:
-  
   repository_dispatch:
-    types: [render_now]schedule:
+    types: [render_now]
+  schedule:
     - cron: "0 0 * * *"  # 09:00 JST (UTC 00:00)
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
修正: repository_dispatch ブロックのインデントと改行を正しくしました。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

