### PR TITLE
ci(render): add path-scoped push trigger

### DIFF
--- a/.github/workflows/render_grafana_png.yml
+++ b/.github/workflows/render_grafana_png.yml
@@ -1,5 +1,9 @@
 name: render-grafana-png
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - ".github/forced-runs/**"
   repository_dispatch:
     types: [render_now]
   schedule:


### PR DESCRIPTION
manual/dispatchの422回避。 へのpushで限定起動。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

