### PR TITLE
feat: CI cutover to k8s-runner + in-cluster Grafana /render

### DIFF
--- a/.github/workflows/render_grafana_png.yml
+++ b/.github/workflows/render_grafana_png.yml
@@ -34,7 +34,11 @@ jobs:
           BASE="http://grafana.monitoring.svc.cluster.local"
           DASH_UID="a128c0c0-c3f9-43e6-8476-dac42fe03110"
           DASH_SLUG="evidence-smoke"
-          curl -sS -G "$BASE/render/d-solo/$DASH_UID/$DASH_SLUG" \
+          AUTH_FLAGS=()
+          if [ -n "${render_user:-}" ] && [ -n "${render_pass:-}" ]; then
+            AUTH_FLAGS=(-u "${render_user}:${render_pass}")
+          fi
+          curl -sSf "${AUTH_FLAGS[@]}" -G "$BASE/render/d-solo/$DASH_UID/$DASH_SLUG" \
             --data-urlencode "from=${{ steps.prep.outputs.from }}" \
             --data-urlencode "to=${{ steps.prep.outputs.to }}" \
             --data-urlencode "orgId=1" \


### PR DESCRIPTION
## Exit Criteria
- runs-on: [self-hosted, k8s-runner] で起動
- Service DNS (grafana.monitoring.svc.cluster.local) へ /render 成功
- Artifacts に out.png と evidence.log（== FOOTER ==）を保存

## Notes
- JST 07:00 は cron: 0 22 * * * (UTC)

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

