### PR TITLE
chore: unify tokens (classic+FGT) & add Token Guard + SSOT

### DIFF
--- a/.github/workflows/token_guard.yml
+++ b/.github/workflows/token_guard.yml
@@ -1,0 +1,16 @@
+name: Token Guard
+on:
+  workflow_dispatch: {}
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify GH_TOKEN can call Actions API
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          set -e
+          gh --version
+          gh api -i /user | sed -n '/^x-oauth-scopes:/Ip' || true
+          gh api /repos/${{ github.repository }}/actions/workflows --paginate >/dev/null
+          echo "OK: Actions API reachable with GH_TOKEN"

--- a/ops/secrets/token_inventory.md
+++ b/ops/secrets/token_inventory.md
@@ -1,0 +1,7 @@
+# Token Inventory (SSOT)
+| Display Name | Type | Perms | Bound Repo(s) | Where used | Owner | Rotate | Notes |
+|---|---|---|---|---|---|---|---|
+| render-bot | classic | repo,workflow | * | GH_TOKEN (local/Codex), dispatch | Hiraku | 2026-01 | Primary execution token |
+| fgpat_vpm-mini_ops-AWCP_20251009 | fine-grained | ActionsRW,ContentsRW,PRRW | HirakuArai/vpm-mini | GH_TOKEN_FG (Codex routine ops) | Hiraku | 2025-12 | Merge; 20251008 slated for revoke |
+| claude_write_token | classic | repo | * | (deprecated) | Hiraku | revoke | Expiring; replace with render-bot |
+| openai-bot-ci | (tbd) | (tbd) | (tbd) | (tbd) | (tbd) | (tbd) | Decide keep/revoke |


### PR DESCRIPTION
## What
- Unify token usage: GH_TOKEN=render-bot (classic), GH_TOKEN_FG=fine-grained
- Replace old names in repo docs/scripts
- Add Token Guard workflow to fail early when token misconfigured
- Add SSOT token inventory (ops/secrets/token_inventory.md)

## Next
- Set Codex GH_TOKEN=render-bot
- Set Codex GH_TOKEN_FG=codex-vpm-mini-actions-rw-p3-4-20251009
- Revoke codex-vpm-mini-actions-rw-p3-4-20251008 after 48h observation

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

