### PR TITLE
ci: render via reusable (workflow_call) + manual wrapper

### DIFF
--- a/.github/workflows/render_manual.yml
+++ b/.github/workflows/render_manual.yml
@@ -1,0 +1,17 @@
+name: Render Manual (wrapper)
+on:
+  workflow_dispatch:
+    inputs:
+      from: { description: "From", required: false, default: "now-30m" }
+      to:   { description: "To",   required: false, default: "now" }
+
+jobs:
+  call-render:
+    name: Call render reusable
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call reusable
+        uses: ./.github/workflows/render_reusable.yml
+        with:
+          from: ${{ github.event.inputs.from }}
+          to:   ${{ github.event.inputs.to }}

--- a/.github/workflows/render_reusable.yml
+++ b/.github/workflows/render_reusable.yml
@@ -1,0 +1,39 @@
+name: Render Reusable (self-hosted)
+on:
+  workflow_call:
+    inputs:
+      from: { type: string, required: false, default: "now-30m" }
+      to:   { type: string, required: false, default: "now" }
+
+jobs:
+  render:
+    name: Render Grafana
+    runs-on: [self-hosted, k8s-runner]
+    steps:
+      - name: Grafana health
+        run: |
+          code=$(curl -s -o /dev/null -w "%{http_code}" http://grafana.monitoring.svc.cluster.local/api/health)
+          echo "HEALTH=$code"; test "$code" = "200"
+
+      - name: Render PNG
+        run: |
+          BASE="http://grafana.monitoring.svc.cluster.local"
+          UID="evidence-prod"
+          SLUG="evidence-e28093-prod"
+          curl -sS -G "$BASE/render/d-solo/$UID/$SLUG" \
+            --data-urlencode "from=${{ inputs.from }}" \
+            --data-urlencode "to=${{ inputs.to }}" \
+            --data-urlencode "orgId=1" \
+            --data-urlencode "panelId=1" \
+            --output out.png
+          file out.png && test -s out.png
+
+      - name: Footer
+        run: echo "== FOOTER == VALIDATE: OK" >> evidence.log
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: grafana-render
+          path: |
+            out.png
+            evidence.log


### PR DESCRIPTION


## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

