### PR TITLE
Guard: avoid UID collision in PNG validation

### DIFF
--- a/.github/workflows/render_reusable.yml
+++ b/.github/workflows/render_reusable.yml
@@ -28,14 +28,14 @@ jobs:
 
           meta=$(cat infra/observability/dashboard_target.json)
           ORG=$(jq -r '.grafana.org'      <<<"$meta")
-          UID=$(jq -r '.grafana.uid'      <<<"$meta")
+          DASH_UID=$(jq -r '.grafana.uid' <<<"$meta")
           SLUG_RAW=$(jq -r '.grafana.slug'<<<"$meta")
-          PANEL=$(jq -r '.grafana.panelId'<<<"$meta")
+          PANEL_ID=$(jq -r '.grafana.panelId'<<<"$meta")
 
           BASE="${GRAFANA_BASE_URL:-http://grafana.monitoring.svc.cluster.local}"
           BASE="${BASE%/}"
 
-          SLUG=$(jq -rn --arg slug "$SLUG_RAW" '$slug|@uri')
+          DASH_SLUG=$(jq -rn --arg slug "$SLUG_RAW" '$slug|@uri')
 
           FROM="${FROM:-${INPUT_FROM:-now-30m}}"
           TO="${TO:-${INPUT_TO:-now}}"
@@ -45,9 +45,9 @@ jobs:
           : > artifacts/evidence.log
           : > artifacts/headers.txt
 
-          URL="${BASE}/render/d-solo/${UID}/${SLUG}"
+          URL="${BASE}/render/d-solo/${DASH_UID}/${DASH_SLUG}"
           echo "URL=${URL}" | tee -a artifacts/evidence.log
-          echo "PARAMS panelId=${PANEL} from=${FROM} to=${TO} orgId=${ORG}" | tee -a artifacts/evidence.log
+          echo "PARAMS panelId=${PANEL_ID} from=${FROM} to=${TO} orgId=${ORG}" | tee -a artifacts/evidence.log
 
           AUTH=()
           if [ -n "${GRAFANA_API_TOKEN:-}" ]; then
@@ -58,7 +58,7 @@ jobs:
             "${AUTH[@]}" \
             -H "X-Org-Id: ${ORG}" \
             -G "$URL" \
-            --data-urlencode "panelId=${PANEL}" \
+            --data-urlencode "panelId=${PANEL_ID}" \
             --data-urlencode "from=${FROM}" \
             --data-urlencode "to=${TO}" \
             --data-urlencode "orgId=${ORG}" \
@@ -69,7 +69,7 @@ jobs:
           SIZE=$( (stat -f%z artifacts/out.png 2>/dev/null || stat -c%s artifacts/out.png 2>/dev/null) || echo 0)
           head -c 16 artifacts/out.png | od -An -tx1 | tr -s ' ' > artifacts/png_head.hex
 
-          echo "HTTP=${HTTP} CT=${CT:-n/a} UID=${UID} panelId=${PANEL} from=${FROM} to=${TO} size=${SIZE}" | tee -a artifacts/evidence.log
+          echo "HTTP=${HTTP} CT=${CT:-n/a} UID=${DASH_UID} panelId=${PANEL_ID} from=${FROM} to=${TO} size=${SIZE}" | tee -a artifacts/evidence.log
           echo "HEADHEX=$(cat artifacts/png_head.hex)" | tee -a artifacts/evidence.log
 
           PNG_SIG_OK=$(head -c 8 artifacts/out.png | xxd -p | awk '{print tolower($0)}' | grep -q '^89504e47' && echo ok || echo ng)


### PR DESCRIPTION
self-hosted runner sets UID env; switch back to DASH_UID/PANEL_ID so hardened guard runs

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  <GRAFANA_BASE_URL>/d/phase1_kpi
  - Chaos Audit:  <GRAFANA_BASE_URL>/d/chaos_audit
- Evidence (this PR):
(none)

