### PR TITLE
CI: self-hosted runner + safe DBG + secrets inheritance

### DIFF
--- a/.github/workflows/render_entrypoint.yml
+++ b/.github/workflows/render_entrypoint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   bridge:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, k8s-runner]
     env:
       GRAFANA_BASE_URL: ${{ vars.GRAFANA_BASE_URL || 'http://grafana.monitoring.svc.cluster.local' }}
       GRAFANA_API_TOKEN: ${{ secrets.GRAFANA_API_TOKEN }}
@@ -28,6 +28,7 @@ jobs:
   reuse:
     needs: bridge
     uses: ./.github/workflows/render_reusable.yml
+    secrets: inherit  # pragma: allowlist secret
     with:
       from: ${{ needs.bridge.outputs.FROM }}
       to:   ${{ needs.bridge.outputs.TO }}

--- a/.github/workflows/render_reusable.yml
+++ b/.github/workflows/render_reusable.yml
@@ -14,6 +14,14 @@ jobs:
     name: Render Grafana
     runs-on: [self-hosted, k8s-runner]
     steps:
+      - name: Debug env wiring (safe)
+        if: always()
+        shell: bash
+        run: |
+          echo "DBG_BASE=${GRAFANA_BASE_URL:-<empty>}"
+          echo "DBG_ORG=${GRAFANA_ORG_ID:-<empty>}"
+          if [ -z "${GRAFANA_API_TOKEN:-}" ]; then echo "DBG_TOKEN=ABSENT"; else echo "DBG_TOKEN=PRESENT"; fi
+
       - uses: actions/checkout@v4
 
       - name: Grafana health


### PR DESCRIPTION
Render経路をself-hostedに固定し、Reusable内で BASE/ORG/TOKEN有無を安全にログ出力。Entrypoint→Reusableでsecrets継承を明示.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

