### PR TITLE
Chore: deep debug for render reusable (token len, health control)

### DIFF
--- a/.github/workflows/render_reusable.yml
+++ b/.github/workflows/render_reusable.yml
@@ -14,13 +14,20 @@ jobs:
     name: Render Grafana
     runs-on: [self-hosted, k8s-runner]
     steps:
-      - name: Debug env wiring (safe)
+      - name: Debug env wiring (deep, safe)
         if: always()
         shell: bash
         run: |
           echo "DBG_BASE=${GRAFANA_BASE_URL:-<empty>}"
           echo "DBG_ORG=${GRAFANA_ORG_ID:-<empty>}"
-          if [ -z "${GRAFANA_API_TOKEN:-}" ]; then echo "DBG_TOKEN=ABSENT"; else echo "DBG_TOKEN=PRESENT"; fi
+          if [ -n "${GRAFANA_API_TOKEN:-}" ]; then
+            echo "DBG_TOKEN=PRESENT"
+            echo "DBG_TOKEN_LEN=$(printf '%s' \"${GRAFANA_API_TOKEN}\" | wc -c)"
+          else
+            echo "DBG_TOKEN=ABSENT"
+            echo "DBG_TOKEN_LEN=0"
+          fi
+          echo "DBG_URL_PREVIEW=${GRAFANA_BASE_URL%/}/render/d-solo/${UID:-<uid>}/${SLUG:-<slug>}?panelId=${PANEL:-<panel>}&from=${FROM:-<from>}&to=${TO:-<to>}&orgId=${ORG:-<org>}"
 
       - uses: actions/checkout@v4
 
@@ -65,6 +72,12 @@ jobs:
           if [ -n "${GRAFANA_API_TOKEN:-}" ]; then
             AUTH+=(-H "Authorization: Bearer ${GRAFANA_API_TOKEN}")
           fi
+
+          HCODE=$(curl -sS -w "%{http_code}" -o /dev/null \
+            "${AUTH[@]}" \
+            -H "X-Org-Id: ${ORG}" \
+            "${BASE}/api/health" || true)
+          echo "CTRL_HEALTH_HTTP=${HCODE}" | tee -a artifacts/evidence.log
 
           HTTP=$(curl -sS -w "%{http_code}" \
             "${AUTH[@]}" \


### PR DESCRIPTION
再利用WF内で BASE/ORG/TOKEN有無/長さと、同ヘッダでの /api/health HTTP を記録して原因を事実で特定。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

