### PR TITLE
CI: reinstall Render Entrypoint (dispatch + push)

### DIFF
--- a/.github/workflows/render-entrypoint.yml
+++ b/.github/workflows/render-entrypoint.yml
@@ -1,20 +1,20 @@
 name: Render Entrypoint
 
 on:
-  push:
-    branches: [ manual-render ]
   workflow_dispatch:
     inputs:
       from: { description: "from", required: false, default: "now-30m" }
       to:   { description: "to",   required: false, default: "now" }
+  push:
+    branches: [ manual-render ]
 
 jobs:
   bridge:
     runs-on: [self-hosted, k8s-runner]
     env:
       GRAFANA_BASE_URL: ${{ vars.GRAFANA_BASE_URL || 'http://grafana.monitoring.svc.cluster.local' }}
-      GRAFANA_API_TOKEN: ${{ secrets.GRAFANA_API_TOKEN }}
-      GRAFANA_ORG_ID: ${{ vars.GRAFANA_ORG_ID || '1' }}
+      GRAFANA_API_TOKEN: ${{ secrets.GRAFANA_API_TOKEN }}  # pragma: allowlist secret
+      GRAFANA_ORG_ID:   ${{ vars.GRAFANA_ORG_ID || '1' }}
     outputs:
       FROM: ${{ steps.set.outputs.FROM }}
       TO:   ${{ steps.set.outputs.TO }}
@@ -22,8 +22,13 @@ jobs:
       - uses: actions/checkout@v4
       - id: set
         run: |
-          echo "FROM=${{ github.event.inputs.from || 'now-30m' }}" >> "$GITHUB_OUTPUT"
-          echo "TO=${{ github.event.inputs.to   || 'now'     }}" >> "$GITHUB_OUTPUT"
+          echo "FROM=${{ github.event.inputs.from || 'now-30m' }}" >> $GITHUB_OUTPUT
+          echo "TO=${{ github.event.inputs.to   || 'now'     }}" >> $GITHUB_OUTPUT
+      - name: Echo params
+        run: |
+          echo "BASE=${GRAFANA_BASE_URL}"
+          echo "ORG=${GRAFANA_ORG_ID}"
+          echo "FROM=${{ steps.set.outputs.FROM }} TO=${{ steps.set.outputs.TO }}"
 
   reuse:
     needs: bridge


### PR DESCRIPTION
確実に一覧・発火できる入口WFをrender-entrypoint.ymlで提供。reusableにsecrets継承、self-hostedで実行。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

