### PR TITLE
Chore: render preflight capture + evidence init

### DIFF
--- a/.github/workflows/render_reusable.yml
+++ b/.github/workflows/render_reusable.yml
@@ -14,22 +14,53 @@ jobs:
     name: Render Grafana
     runs-on: [self-hosted, k8s-runner]
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Init evidence log
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          : > artifacts/evidence.log
+          : > artifacts/headers.txt
+
+      - name: Load dashboard metadata
+        shell: bash
+        run: |
+          meta=$(cat infra/observability/dashboard_target.json)
+          ORG=$(jq -r '.grafana.org' <<<"$meta")
+          UID=$(jq -r '.grafana.uid' <<<"$meta")
+          SLUG=$(jq -r '.grafana.slug'<<<"$meta")
+          PANEL=$(jq -r '.grafana.panelId'<<<"$meta")
+          {
+            echo "DASH_ORG=$ORG"
+            echo "DASH_UID=$UID"
+            echo "DASH_SLUG=$SLUG"
+            echo "DASH_PANEL=$PANEL"
+          } >> "$GITHUB_ENV"
+          echo "SSOT_ORG=$ORG" | tee -a artifacts/evidence.log
+          echo "SSOT_UID=$UID" | tee -a artifacts/evidence.log
+          echo "SSOT_SLUG=$SLUG" | tee -a artifacts/evidence.log
+          echo "SSOT_PANEL=$PANEL" | tee -a artifacts/evidence.log
+
       - name: Debug env wiring (deep, safe)
         if: always()
         shell: bash
         run: |
-          echo "DBG_BASE=${GRAFANA_BASE_URL:-<empty>}"
-          echo "DBG_ORG=${GRAFANA_ORG_ID:-<empty>}"
+          echo "DBG_BASE=${GRAFANA_BASE_URL:-<empty>}" | tee -a artifacts/evidence.log
+          echo "DBG_ORG=${GRAFANA_ORG_ID:-<empty>}" | tee -a artifacts/evidence.log
           if [ -n "${GRAFANA_API_TOKEN:-}" ]; then
-            echo "DBG_TOKEN=PRESENT"
-            echo "DBG_TOKEN_LEN=$(printf '%s' \"${GRAFANA_API_TOKEN}\" | wc -c)"
+            echo "DBG_TOKEN=PRESENT" | tee -a artifacts/evidence.log
+            len=$(printf '%s' "${GRAFANA_API_TOKEN}" | wc -c | tr -d '[:space:]')
+            echo "DBG_TOKEN_LEN=${len}" | tee -a artifacts/evidence.log
           else
-            echo "DBG_TOKEN=ABSENT"
-            echo "DBG_TOKEN_LEN=0"
+            echo "DBG_TOKEN=ABSENT" | tee -a artifacts/evidence.log
+            echo "DBG_TOKEN_LEN=0" | tee -a artifacts/evidence.log
           fi
-          echo "DBG_URL_PREVIEW=${GRAFANA_BASE_URL%/}/render/d-solo/${UID:-<uid>}/${SLUG:-<slug>}?panelId=${PANEL:-<panel>}&from=${FROM:-<from>}&to=${TO:-<to>}&orgId=${ORG:-<org>}"
-
-      - uses: actions/checkout@v4
+          echo "DBG_DASH_UID=${DASH_UID:-<unset>}" | tee -a artifacts/evidence.log
+          echo "DBG_DASH_SLUG=${DASH_SLUG:-<unset>}" | tee -a artifacts/evidence.log
+          echo "DBG_DASH_PANEL=${DASH_PANEL:-<unset>}" | tee -a artifacts/evidence.log
+          echo "DBG_URL_PREVIEW=${GRAFANA_BASE_URL%/}/render/d-solo/${DASH_UID:-<uid>}/${DASH_SLUG:-<slug>}?panelId=${DASH_PANEL:-<panel>}" | tee -a artifacts/evidence.log
 
       - name: Grafana health
         run: |
@@ -45,45 +76,49 @@ jobs:
         run: |
           set -euo pipefail
 
-          meta=$(cat infra/observability/dashboard_target.json)
-          ORG=$(jq -r '.grafana.org'      <<<"$meta")
-          DASH_UID=$(jq -r '.grafana.uid' <<<"$meta")
-          SLUG_RAW=$(jq -r '.grafana.slug'<<<"$meta")
-          PANEL_ID=$(jq -r '.grafana.panelId'<<<"$meta")
+          ORG="${DASH_ORG}"
+          UID="${DASH_UID}"
+          SLUG="${DASH_SLUG}"
+          PANEL="${DASH_PANEL}"
 
           BASE="${GRAFANA_BASE_URL:-http://grafana.monitoring.svc.cluster.local}"
           BASE="${BASE%/}"
-
-          DASH_SLUG=$(jq -rn --arg slug "$SLUG_RAW" '$slug|@uri')
 
           FROM="${FROM:-${INPUT_FROM:-now-30m}}"
           TO="${TO:-${INPUT_TO:-now}}"
           MIN_PNG_BYTES="${MIN_PNG_BYTES:-512}"
 
-          mkdir -p artifacts
-          : > artifacts/evidence.log
-          : > artifacts/headers.txt
-
-          URL="${BASE}/render/d-solo/${DASH_UID}/${DASH_SLUG}"
+          URL="${BASE}/render/d-solo/${UID}/${SLUG}"
           echo "URL=${URL}" | tee -a artifacts/evidence.log
-          echo "PARAMS panelId=${PANEL_ID} from=${FROM} to=${TO} orgId=${ORG}" | tee -a artifacts/evidence.log
+          echo "PARAMS panelId=${PANEL} from=${FROM} to=${TO} orgId=${ORG}" | tee -a artifacts/evidence.log
 
           AUTH=()
           if [ -n "${GRAFANA_API_TOKEN:-}" ]; then
             AUTH+=(-H "Authorization: Bearer ${GRAFANA_API_TOKEN}")
           fi
 
-          HCODE=$(curl -sS -w "%{http_code}" -o /dev/null \
+          PRE_HEALTH_HTTP=$(curl -sS -D artifacts/pre_health.headers.txt -w "%{http_code}" \
             "${AUTH[@]}" \
             -H "X-Org-Id: ${ORG}" \
-            "${BASE}/api/health" || true)
-          echo "CTRL_HEALTH_HTTP=${HCODE}" | tee -a artifacts/evidence.log
+            -o /dev/null "${BASE}/api/health" || true)
+          echo "CTRL_HEALTH_HTTP=${PRE_HEALTH_HTTP}" | tee -a artifacts/evidence.log
+
+          PRE_RENDER_HTTP=$(curl -sS -D artifacts/pre_render.headers.txt -w "%{http_code}" \
+            "${AUTH[@]}" \
+            -H "X-Org-Id: ${ORG}" \
+            -G "$URL" \
+            --data-urlencode "panelId=${PANEL}" \
+            --data-urlencode "from=${FROM}" \
+            --data-urlencode "to=${TO}" \
+            --data-urlencode "orgId=${ORG}" \
+            -o /dev/null || true)
+          echo "CTRL_RENDER_HTTP=${PRE_RENDER_HTTP}" | tee -a artifacts/evidence.log
 
           HTTP=$(curl -sS -w "%{http_code}" \
             "${AUTH[@]}" \
             -H "X-Org-Id: ${ORG}" \
             -G "$URL" \
-            --data-urlencode "panelId=${PANEL_ID}" \
+            --data-urlencode "panelId=${PANEL}" \
             --data-urlencode "from=${FROM}" \
             --data-urlencode "to=${TO}" \
             --data-urlencode "orgId=${ORG}" \
@@ -94,7 +129,7 @@ jobs:
           SIZE=$( (stat -f%z artifacts/out.png 2>/dev/null || stat -c%s artifacts/out.png 2>/dev/null) || echo 0)
           head -c 16 artifacts/out.png | od -An -tx1 | tr -s ' ' > artifacts/png_head.hex
 
-          echo "HTTP=${HTTP} CT=${CT:-n/a} UID=${DASH_UID} panelId=${PANEL_ID} from=${FROM} to=${TO} size=${SIZE}" | tee -a artifacts/evidence.log
+          echo "HTTP=${HTTP} CT=${CT:-n/a} UID=${UID} panelId=${PANEL} from=${FROM} to=${TO} size=${SIZE}" | tee -a artifacts/evidence.log
           echo "HEADHEX=$(cat artifacts/png_head.hex)" | tee -a artifacts/evidence.log
 
           PNG_SIG_OK=$(head -c 8 artifacts/out.png | xxd -p | awk '{print tolower($0)}' | grep -q '^89504e47' && echo ok || echo ng)
@@ -112,11 +147,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: grafana-render
-          path: |
-            artifacts/out.png
-            artifacts/evidence.log
-            artifacts/headers.txt
-            artifacts/png_head.hex
+          path: artifacts/
 
       - name: Fail if NG
         if: steps.render.outputs.result == 'ng'


### PR DESCRIPTION
再利用WFにpreflight計測を追加し、/api/healthと/renderのHTTP/Location等をevidenceに記録。失敗時でも証跡が必ず残るように補強。

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

