### PR TITLE
CI: add minimal permissions to entrypoint

### DIFF
--- a/.github/workflows/render-entrypoint.yml
+++ b/.github/workflows/render-entrypoint.yml
@@ -1,4 +1,7 @@
 name: Render Entrypoint
+permissions:
+  contents: read
+  actions: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/render_reusable.yml
+++ b/.github/workflows/render_reusable.yml
@@ -1,4 +1,6 @@
 name: Render Reusable (self-hosted)
+permissions:
+  contents: read
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Ensure Render Entrypoint and reusable workflows declare contents/actions read permissions so jobs start even under restrictive repo defaults.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

