### PR TITLE
ci: add render_manual_min (manual dispatch smoke)

### DIFF
--- a/.github/workflows/render_manual_min.yml
+++ b/.github/workflows/render_manual_min.yml
@@ -1,0 +1,17 @@
+name: Render Manual Min
+on:
+  workflow_dispatch:
+    inputs:
+      from: { description: "from", required: false, default: "now-30m" }
+      to:   { description: "to",   required: false, default: "now" }
+jobs:
+  render:
+    runs-on: [self-hosted, k8s-runner]
+    permissions: { contents: write }
+    steps:
+      - uses: actions/checkout@v4
+      - name: Smoke write
+        run: |
+          echo ok > out.png && test -s out.png
+          mkdir -p reports
+          printf "# Smoke OK %s\n" "$(date -u)" > reports/daily.md


### PR DESCRIPTION
Minimal manual-only workflow to verify dispatch path & in-cluster runner.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

