### PR TITLE
ci: fix notify script expressions for render workflow

### DIFF
--- a/.github/workflows/render_grafana_png.yml
+++ b/.github/workflows/render_grafana_png.yml
@@ -77,12 +77,13 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            const title = `Render Grafana PNG failed on ${{context.ref}} (${{context.runId}})`;
+            const runId = context.runId;
+            const title = `Render Grafana PNG failed on ${context.ref} (${runId})`;
             const body = [
               'Auto-opened because /render job failed.',
               '',
-              `Run: ${{context.serverUrl}}/${{context.repo.owner}}/${{context.repo.repo}}/actions/runs/${{context.runId}}`,
-              `Commit: ${{context.sha}}`
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}`,
+              `Commit: ${context.sha}`
             ].join('\n');
             await github.rest.issues.create({
               owner: context.repo.owner,


### PR DESCRIPTION
Use github-script context directly instead of unresolved expression placeholders so the workflow parses and failure notifications continue working.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

