### PR TITLE
ci: render manual proxy (workaround 422)

### DIFF
--- a/.github/workflows/render_grafana_png.yml
+++ b/.github/workflows/render_grafana_png.yml
@@ -2,6 +2,20 @@
 name: Render Grafana PNG
 
 on:
+  workflow_call:
+    inputs:
+      from:
+        required: false
+        type: string
+        default: "now-30m"
+      to:
+        required: false
+        type: string
+        default: "now"
+      force_fail:
+        required: false
+        type: string
+        default: "false"
   workflow_dispatch:
     inputs:
       from:

--- a/.github/workflows/render_manual_proxy.yml
+++ b/.github/workflows/render_manual_proxy.yml
@@ -1,0 +1,14 @@
+name: Render Manual Proxy
+on:
+  workflow_dispatch:
+    inputs:
+      from: { description: "from", required: false, default: "now-30m" }
+      to:   { description: "to",   required: false, default: "now" }
+      force_fail: { description: "force", required: false, default: "false" }
+jobs:
+  proxy:
+    uses: ./.github/workflows/render_grafana_png.yml
+    with:
+      from: ${{ github.event.inputs.from }}
+      to: ${{ github.event.inputs.to }}
+      force_fail: ${{ github.event.inputs.force_fail }}


### PR DESCRIPTION
Make renderer reusable (workflow_call) and add a manual proxy workflow to trigger it.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

