### PR TITLE
ci: fix render workflow inputs for reuse

### DIFF
--- a/.github/workflows/render_grafana_png.yml
+++ b/.github/workflows/render_grafana_png.yml
@@ -46,11 +46,11 @@ jobs:
       - name: Prepare params
         id: prep
         run: |
-          FROM="${{ github.event.inputs.from || 'now-30m' }}"
-          TO="${{ github.event.inputs.to   || 'now' }}"
+          FROM="${{ inputs.from }}"
+          TO="${{ inputs.to }}"
           echo "from=$FROM" >> $GITHUB_OUTPUT
           echo "to=$TO"     >> $GITHUB_OUTPUT
-          FORCE_FAIL="${{ github.event.inputs.force_fail || 'false' }}"
+          FORCE_FAIL="${{ inputs.force_fail }}"
           echo "force_fail=$FORCE_FAIL" >> $GITHUB_OUTPUT
 
       - name: Render dashboard (anonymous, in-cluster)


### PR DESCRIPTION
Use reusable workflow inputs instead of github.event to support workflow_call invocations.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

