### PR TITLE
ci: proxy inherits secrets + token perms

### DIFF
--- a/.github/workflows/render_manual_proxy.yml
+++ b/.github/workflows/render_manual_proxy.yml
@@ -1,4 +1,7 @@
 name: Render Manual Proxy
+permissions:
+  contents: write
+  pull-requests: write
 on:
   workflow_dispatch:
     inputs:
@@ -12,3 +15,4 @@ jobs:
       from: ${{ github.event.inputs.from }}
       to: ${{ github.event.inputs.to }}
       force_fail: ${{ github.event.inputs.force_fail }}
+    secrets: inherit  # pragma: allowlist secret


### PR DESCRIPTION
Ensure reusable renderer sees GITHUB_TOKEN and secrets when called via proxy.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

