### PR TITLE
ci: allow workflow_call in renderer

### DIFF
--- a/.github/workflows/render_grafana_png.yml
+++ b/.github/workflows/render_grafana_png.yml
@@ -122,7 +122,7 @@ jobs:
           labels: "evidence,bot"
 
       - name: Enable auto-merge (squash) for evidence PR
-        if: always() && steps.cpr.outputs.pull-request-number
+        if: always() && steps.cpr.outputs.pull-request-number || github.event_name == 'workflow_call'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}


### PR DESCRIPTION
Ensure render job runs when called via reusable workflow (proxy).

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

