### PR TITLE
ci: unblock reusable renderer (workflow_call path)

### DIFF
--- a/.github/workflows/render_grafana_png.yml
+++ b/.github/workflows/render_grafana_png.yml
@@ -122,7 +122,6 @@ jobs:
           labels: "evidence,bot"
 
       - name: Enable auto-merge (squash) for evidence PR
-        if: always() && steps.cpr.outputs.pull-request-number || github.event_name == 'workflow_call'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/render_manual_proxy.yml
+++ b/.github/workflows/render_manual_proxy.yml
@@ -15,4 +15,5 @@ jobs:
       from: ${{ github.event.inputs.from }}
       to: ${{ github.event.inputs.to }}
       force_fail: ${{ github.event.inputs.force_fail }}
+    permissions: inherit
     secrets: inherit  # pragma: allowlist secret


### PR DESCRIPTION
Drop jobs.render if-guard; ensure proxy inherits permissions+secrets.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

