### PR TITLE
debug: reusable smoke (call+proxy)

### DIFF
--- a/.github/workflows/_call_proxy.yml
+++ b/.github/workflows/_call_proxy.yml
@@ -1,0 +1,10 @@
+name: _call_proxy
+on:
+  workflow_dispatch:
+jobs:
+  proxy:
+    uses: ./.github/workflows/_callable_smoke.yml
+    with:
+      msg: "proxy→call ok"
+    permissions: inherit
+    secrets: inherit  # pragma: allowlist secret

--- a/.github/workflows/_callable_smoke.yml
+++ b/.github/workflows/_callable_smoke.yml
@@ -1,0 +1,17 @@
+name: _callable_smoke
+on:
+  workflow_call:
+    inputs:
+      msg:
+        required: false
+        type: string
+        default: "hello-from-call"
+jobs:
+  echo:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ inputs.msg }}" | tee smoke.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: smoke
+          path: smoke.txt


### PR DESCRIPTION
Verify workflow_call path independently of renderer.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

