### PR TITLE
ci: evidence PR clean diff (add-paths: reports/daily.md)

### DIFF
--- a/.github/workflows/render_grafana_png.yml
+++ b/.github/workflows/render_grafana_png.yml
@@ -120,6 +120,8 @@ jobs:
           delete-branch: true
           base: "main"
           labels: "evidence,bot"
+          add-paths: |
+            reports/daily.md
 
       - name: Enable auto-merge (squash) for evidence PR
         env:


### PR DESCRIPTION
Make evidence PR include only reports/daily.md. Artifacts remain as Actions artifacts.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

