### PR TITLE
P1: Guard runner labels (no artifact duplication)

### DIFF
--- a/.github/workflows/render_grafana_png.yml
+++ b/.github/workflows/render_grafana_png.yml
@@ -41,6 +41,12 @@ jobs:
       pull-requests: write
     timeout-minutes: 10
     steps:
+      - name: Guard: enforce runner labels
+        if: ${{ !contains(runner.labels, 'self-hosted') || !contains(runner.labels, 'k8s-runner') }}
+        run: |
+          echo "This workflow must run on [self-hosted, k8s-runner]."
+          echo "Current labels: ${{ toJson(runner.labels) }}"
+          exit 1
       - uses: actions/checkout@v4
 
       - name: Prepare params


### PR DESCRIPTION
Add YAML-level runner label guard using runner.labels; keep existing artifact upload and Stamp; no direct pushes to main.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

