### PR TITLE
P2': contracts bootstrap (PR-based, outputs for date)

### DIFF
--- a/.github/workflows/synthesize_decisions.yml
+++ b/.github/workflows/synthesize_decisions.yml
@@ -1,0 +1,44 @@
+name: synthesize_decisions
+on:
+  schedule: [{ cron: "5 22 * * *" }]  # JST 07:05
+  workflow_dispatch: {}
+jobs:
+  decide:
+    runs-on: [self-hosted, k8s-runner]
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute metadata
+        id: now
+        run: |
+          echo "date=$(date +%F)" >> "$GITHUB_OUTPUT"
+          echo "run_id=${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate decision card (stub)
+        run: |
+          mkdir -p reports
+          D="${{ steps.now.outputs.date }}"
+          {
+            echo "# Daily Decision — ${D}"
+            echo
+            echo "Status: GREEN（bootstrap）"
+            echo
+            echo "**Today (max 3)**"
+            echo "- なし"
+            echo
+            echo "Evidence: <TBD>"
+            echo "FOOTER: RUN=${{ steps.now.outputs.run_id }} VERIFY=stub"
+          } > "reports/decision_${D}.md"
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: "chore/decision-${{ steps.now.outputs.date }}-${{ steps.now.outputs.run_id }}"
+          title: "decision: ${{ steps.now.outputs.date }}"
+          body: "bootstrap decision card (stub). No binaries; PR-based flow."
+          commit-message: "decision: ${{ steps.now.outputs.date }}"
+          add-paths: |
+            reports/decision_*.md

--- a/.github/workflows/validate_contracts.yml
+++ b/.github/workflows/validate_contracts.yml
@@ -1,0 +1,9 @@
+name: validate_contracts
+on: [push, pull_request]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y yamllint
+      - run: yamllint contracts

--- a/contracts/actions/self_cost_health.yaml
+++ b/contracts/actions/self_cost_health.yaml
@@ -1,0 +1,6 @@
+if: "external_ip_zero == false || unused_pds_zero == false || runtime_minutes:red"
+then:
+  - title: "Self-Cost 健全性逸脱（IP/PD/Runtime）"
+    owner: "@ops-lead"
+    due: "EOD"
+    success: "外部IP=0・未使用PD=0・実行≤10分の証跡をEvidenceに添付"

--- a/contracts/kpi_catalog.yaml
+++ b/contracts/kpi_catalog.yaml
@@ -1,0 +1,9 @@
+kpis:
+  - id: self_cost_health
+    title: Self Health / Cost
+    owner: "@ops-lead"
+    render: "md"
+  - id: change_pr_flow
+    title: Change / PR Flow
+    owner: "@dev-lead"
+    render: "md"

--- a/contracts/metrics/self_cost_health.yaml
+++ b/contracts/metrics/self_cost_health.yaml
@@ -1,0 +1,11 @@
+id: self_cost_health
+compute:
+  kpis:
+    external_ip_zero: "addresses == 0"
+    unused_pds_zero:  "unused_pds == 0"
+    runtime_minutes:  "runtime_minutes"
+thresholds:
+  external_ip_zero: {green: "== true", red: "== false"}
+  unused_pds_zero:  {green: "== true", red: "== false"}
+  runtime_minutes:  {green: "<= 10", yellow: "<= 15", red: "> 15"}
+schedule: "5 7 * * *"

--- a/templates/decision_card.md
+++ b/templates/decision_card.md
@@ -1,0 +1,10 @@
+# Daily Decision — {{date}}
+Status: {{status}}（{{key_points}})
+
+**Today (max 3)**
+{{#actions}}
+- {{title}} — Owner: {{owner}}, Due: {{due}}, Success: {{success}}
+{{/actions}}
+
+Evidence: {{evidence_links}}
+FOOTER: RUN={{run_id}} VERIFY={{verify}}


### PR DESCRIPTION
Add synthesize_decisions with outputs-based metadata; create PR instead of pushing to main; MD only.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

