### PR TITLE
P1: fix wrapper uses (FQ + inherit secrets)

### DIFF
--- a/.github/workflows/render_manual.yml
+++ b/.github/workflows/render_manual.yml
@@ -8,7 +8,11 @@ on:
 jobs:
   call-render:
     name: Render Grafana manual
-    uses: ./.github/workflows/render_reusable.yml
+    permissions:
+      contents: read
+    uses: HirakuArai/vpm-mini/.github/workflows/render_reusable.yml@main
+    # pass repo secrets to the called workflow
+    secrets: "inherit"  # pragma: allowlist secret
     with:
       from: ${{ github.event.inputs.from || 'now-30m' }}
       to:   ${{ github.event.inputs.to   || 'now' }}


### PR DESCRIPTION
Call reusable as HirakuArai/vpm-mini/.github/workflows/render_reusable.yml@main and pass secrets. This avoids jobs=0 immediate failure seen with relative uses: path.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

