### PR TITLE
P1: wrapper workflow needs actions permission

### DIFF
--- a/.github/workflows/render_manual.yml
+++ b/.github/workflows/render_manual.yml
@@ -9,10 +9,11 @@ jobs:
   call-render:
     name: Render Grafana manual
     permissions:
+      actions: read
       contents: read
     uses: HirakuArai/vpm-mini/.github/workflows/render_reusable.yml@main
     # pass repo secrets to the called workflow
-    secrets: "inherit"  # pragma: allowlist secret
+    secrets: inherit  # pragma: allowlist secret
     with:
       from: ${{ github.event.inputs.from || 'now-30m' }}
       to:   ${{ github.event.inputs.to   || 'now' }}


### PR DESCRIPTION
Allow the manual wrapper to call the reusable workflow by keeping actions: read in addition to contents: read.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

