### PR TITLE
P1: render_manual needs top-level permissions

### DIFF
--- a/.github/workflows/render_manual.yml
+++ b/.github/workflows/render_manual.yml
@@ -5,12 +5,13 @@ on:
       from: { description: "From", required: false, default: "now-30m" }
       to:   { description: "To",   required: false, default: "now" }
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   call-render:
     name: Render Grafana manual
-    permissions:
-      actions: read
-      contents: read
     uses: HirakuArai/vpm-mini/.github/workflows/render_reusable.yml@main
     # pass repo secrets to the called workflow
     secrets: inherit  # pragma: allowlist secret


### PR DESCRIPTION
Expose actions/read and contents/read at the workflow level so the reusable call can fetch render_reusable.yml before jobs are created.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

