### PR TITLE
P1: wrapper → relative uses for same-repo reusable

### DIFF
--- a/.github/workflows/render_manual.yml
+++ b/.github/workflows/render_manual.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   call-render:
     name: Render Grafana manual
-    uses: HirakuArai/vpm-mini/.github/workflows/render_reusable.yml@main
+    uses: ./.github/workflows/render_reusable.yml
     # pass repo secrets to the called workflow
     secrets: inherit  # pragma: allowlist secret
     with:


### PR DESCRIPTION
Switch back to path-based uses for same-repo reusable to avoid pre-plan resolution failures. Keep top-level permissions (actions/contents read) and secrets: inherit.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

