### PR TITLE
P1: reusable needs top-level permissions (actions/contents: read)

### DIFF
--- a/.github/workflows/render_reusable.yml
+++ b/.github/workflows/render_reusable.yml
@@ -1,5 +1,6 @@
 name: Render Reusable (self-hosted)
 permissions:
+  actions: read
   contents: read
 on:
   workflow_call:


### PR DESCRIPTION
Expose actions/read alongside contents/read so reusable workflows can be fetched before jobs are planned.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

