### PR TITLE
P1: wrapper — drop secrets: inherit for call test

### DIFF
--- a/.github/workflows/render_manual.yml
+++ b/.github/workflows/render_manual.yml
@@ -13,8 +13,6 @@ jobs:
   call-render:
     name: Render Grafana manual
     uses: ./.github/workflows/render_reusable.yml
-    # pass repo secrets to the called workflow
-    secrets: inherit  # pragma: allowlist secret
     with:
       from: ${{ github.event.inputs.from || 'now-30m' }}
       to:   ${{ github.event.inputs.to   || 'now' }}


### PR DESCRIPTION
Temporarily remove secrets propagation to confirm wrapper planning succeeds without extra token scopes.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

