### PR TITLE
P1: wrapper — add plan smoke job

### DIFF
--- a/.github/workflows/render_manual.yml
+++ b/.github/workflows/render_manual.yml
@@ -16,3 +16,8 @@ jobs:
     with:
       from: ${{ github.event.inputs.from || 'now-30m' }}
       to:   ${{ github.event.inputs.to   || 'now' }}
+
+  plan-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "planner OK"


### PR DESCRIPTION
Add a trivial ubuntu job so we can spot pre-plan failures (plan-smoke) alongside the reusable call.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

