### PR TITLE
probe: planner without call-render

### DIFF
--- a/.github/workflows/render_manual.yml
+++ b/.github/workflows/render_manual.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   call-render:
     name: Render Grafana manual
+    if: ${{ false }}
     uses: ./.github/workflows/render_reusable.yml
     with:
       from: ${{ github.event.inputs.from || 'now-30m' }}


### PR DESCRIPTION
Disable the reusable call with `if: ${{ false }}` and ensure plan-smoke exists so we can confirm the planner produces jobs.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

