### PR TITLE
hotfix: minimal valid render_manual (planner probe)

### DIFF
--- a/.github/workflows/render_manual.yml
+++ b/.github/workflows/render_manual.yml
@@ -1,24 +1,29 @@
 name: Render Manual (wrapper)
+
 on:
   workflow_dispatch:
     inputs:
-      from: { description: "From", required: false, default: "now-30m" }
-      to:   { description: "To",   required: false, default: "now" }
+      from:
+        description: "From"
+        required: false
+        default: "now-30m"
+      to:
+        description: "To"
+        required: false
+        default: "now"
 
 permissions:
   actions: read
   contents: read
 
-jobs:
-  call-render:
-    name: Render Grafana manual
-    if: ${{ false }}
-    uses: ./.github/workflows/render_reusable.yml
-    with:
-      from: ${{ github.event.inputs.from || 'now-30m' }}
-      to:   ${{ github.event.inputs.to   || 'now' }}
+concurrency:
+  group: render-manual
+  cancel-in-progress: false
 
-  plan-smoke:
+jobs:
+  smoke:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "planner OK"
+      - name: Planner OK
+        run: |
+          echo "planner OK: ${GITHUB_RUN_ID}"


### PR DESCRIPTION
Replace render_manual.yml with a minimal, planner-safe workflow to isolate invalid structure.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

