### PR TITLE
hotfix: ensure checkout before running render-grafana action

### DIFF
--- a/.github/actions/render-grafana/action.yml
+++ b/.github/actions/render-grafana/action.yml
@@ -10,7 +10,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
     - name: Init
       shell: bash
       run: |

--- a/.github/workflows/render_manual.yml
+++ b/.github/workflows/render_manual.yml
@@ -31,6 +31,7 @@ jobs:
   call-render-inline:
     runs-on: [self-hosted, k8s-runner]
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/render-grafana
         with:
           from: ${{ github.event.inputs.from || 'now-30m' }}


### PR DESCRIPTION
Run actions/checkout in the render job so the local composite action metadata is available, and drop the redundant checkout inside the composite.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

