### PR TITLE
hotfix: pass grafana env into composite action

### DIFF
--- a/.github/actions/render-grafana/action.yml
+++ b/.github/actions/render-grafana/action.yml
@@ -43,11 +43,10 @@ runs:
       env:
         INPUT_FROM: ${{ inputs.from }}
         INPUT_TO: ${{ inputs.to }}
-        GRAFANA_BASE_URL: ${{ vars.GRAFANA_BASE_URL || 'http://grafana.monitoring.svc.cluster.local' }}
-        GRAFANA_API_TOKEN: ${{ secrets.GRAFANA_API_TOKEN }}
       run: |
         set -euo pipefail
-        BASE="${GRAFANA_BASE_URL%/}"
+        BASE="${GRAFANA_BASE_URL:-http://grafana.monitoring.svc.cluster.local}"
+        BASE="${BASE%/}"
         URL="${BASE}/render/d-solo/${DASH_UID}/${DASH_SLUG}"
         FROM="${INPUT_FROM}"; TO="${INPUT_TO}"
         AUTH=()

--- a/.github/workflows/render_manual.yml
+++ b/.github/workflows/render_manual.yml
@@ -36,3 +36,6 @@ jobs:
         with:
           from: ${{ github.event.inputs.from || 'now-30m' }}
           to:   ${{ github.event.inputs.to   || 'now' }}
+        env:
+          GRAFANA_BASE_URL: ${{ vars.GRAFANA_BASE_URL || 'http://grafana.monitoring.svc.cluster.local' }}
+          GRAFANA_API_TOKEN: ${{ secrets.GRAFANA_API_TOKEN }}


### PR DESCRIPTION
Provide GRAFANA_BASE_URL and GRAFANA_API_TOKEN from the workflow step instead of referencing vars/secrets inside the composite action.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

