### PR TITLE
hotfix: add grafana diagnostics and harden render logs

### DIFF
--- a/.github/actions/render-grafana/action.yml
+++ b/.github/actions/render-grafana/action.yml
@@ -43,22 +43,40 @@ runs:
       env:
         INPUT_FROM: ${{ inputs.from }}
         INPUT_TO: ${{ inputs.to }}
+        GRAFANA_BASE_URL: ${{ env.GRAFANA_BASE_URL || 'http://grafana.monitoring.svc.cluster.local' }}
+        GRAFANA_API_TOKEN: ${{ env.GRAFANA_API_TOKEN }}
       run: |
         set -euo pipefail
-        BASE="${GRAFANA_BASE_URL:-http://grafana.monitoring.svc.cluster.local}"
-        BASE="${BASE%/}"
-        URL="${BASE}/render/d-solo/${DASH_UID}/${DASH_SLUG}"
+        BASE="${GRAFANA_BASE_URL%/}"
+        UID="${DASH_UID}"; SLUG="${DASH_SLUG}"; PANEL="${DASH_PANEL}"
         FROM="${INPUT_FROM}"; TO="${INPUT_TO}"
+        ORG="${DASH_ORG}"
+        URL="${BASE}/render/d-solo/${UID}/${SLUG}"
+        echo "BASE=$BASE UID=$UID SLUG=$SLUG PANEL=$PANEL ORG=$ORG FROM=$FROM TO=$TO" | tee -a artifacts/evidence.log
+
         AUTH=()
         [ -n "${GRAFANA_API_TOKEN:-}" ] && AUTH+=(-H "Authorization: Bearer ${GRAFANA_API_TOKEN}")
-        HTTP=$(curl -sS -w "%{http_code}" "${AUTH[@]}" -H "X-Org-Id: ${DASH_ORG}" \
-          -G "$URL" --data-urlencode panelId="${DASH_PANEL}" \
-          --data-urlencode from="${FROM}" --data-urlencode to="${TO}" \
-          -D artifacts/headers.txt -o artifacts/out.png || true)
-        CT=$(grep -i '^content-type:' artifacts/headers.txt | awk '{print tolower($2)}' | tr -d '\r')
-        SIZE=$(stat -c%s artifacts/out.png 2>/dev/null || stat -f%z artifacts/out.png 2>/dev/null || echo 0)
-        SIG=$(head -c 8 artifacts/out.png | xxd -p | awk '{print tolower($0)}')
-        echo "HTTP=${HTTP} CT=${CT:-n/a} SIZE=${SIZE} SIG=${SIG}" | tee -a artifacts/evidence.log
+
+        CODE=$(curl -sS -m 20 -w "%{http_code}" -I -G "${AUTH[@]}" -H "X-Org-Id: ${ORG}" \
+          "$URL" --data-urlencode panelId="${PANEL}" --data-urlencode from="${FROM}" --data-urlencode to="${TO}" -o /dev/null || true)
+        echo "PRE_HTTP=${CODE}" | tee -a artifacts/evidence.log
+
+        HTTP=""; CT=""; SIZE=0; SIG=""
+        for i in 1 2 3; do
+          HTTP=$(curl -sS -m 60 --retry 2 --retry-delay 2 --retry-all-errors \
+            -w "%{http_code}" -G "${AUTH[@]}" -H "X-Org-Id: ${ORG}" \
+            "$URL" --data-urlencode panelId="${PANEL}" --data-urlencode from="${FROM}" --data-urlencode to="${TO}" \
+            -D artifacts/headers.txt -o artifacts/out.png || true)
+          CT=$(grep -i '^content-type:' artifacts/headers.txt | awk '{print tolower($2)}' | tr -d '\r')
+          SIZE=$(stat -c%s artifacts/out.png 2>/dev/null || stat -f%z artifacts/out.png 2>/dev/null || echo 0)
+          SIG=$(head -c 8 artifacts/out.png | xxd -p | awk '{print tolower($0)}')
+          echo "TRY=$i HTTP=${HTTP} CT=${CT:-n/a} SIZE=${SIZE} SIG=${SIG}" | tee -a artifacts/evidence.log
+          if [ "$HTTP" = "200" ] && echo "$CT" | grep -q 'image/png' && [ "$SIZE" -ge 512 ] && echo "$SIG" | grep -q '^89504e47'; then
+            break
+          fi
+          sleep 2
+        done
+
         if [ "$HTTP" = "200" ] && echo "$CT" | grep -q 'image/png' && [ "$SIZE" -ge 512 ] && echo "$SIG" | grep -q '^89504e47'; then
           echo "== FOOTER == OK" | tee -a artifacts/evidence.log
         else

--- a/.github/workflows/render_manual.yml
+++ b/.github/workflows/render_manual.yml
@@ -28,6 +28,53 @@ jobs:
         run: |
           echo "planner OK: ${GITHUB_RUN_ID}"
 
+  call-render-diag:
+    runs-on: [self-hosted, k8s-runner]
+    env:
+      GRAFANA_BASE_URL: ${{ vars.GRAFANA_BASE_URL || 'http://grafana.monitoring.svc.cluster.local' }}
+      GRAFANA_API_TOKEN: ${{ secrets.GRAFANA_API_TOKEN }}
+      GRAFANA_ORG_ID: ${{ vars.GRAFANA_ORG_ID || '1' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Show env + DNS
+        shell: bash
+        run: |
+          echo "BASE=${GRAFANA_BASE_URL:-<unset>}"
+          echo "ORG=${GRAFANA_ORG_ID:-<unset>}"
+          if [ -n "${GRAFANA_API_TOKEN:-}" ]; then echo "TOKEN=PRESENT"; else echo "TOKEN=ABSENT"; fi
+          echo "---- resolv.conf ----"; cat /etc/resolv.conf || true
+          echo "---- nslookup ----";  (command -v nslookup >/dev/null && nslookup grafana.monitoring.svc.cluster.local) || true
+          echo "---- getent hosts ----"; getent hosts grafana.monitoring.svc.cluster.local || true
+      - name: Health check (no auth)
+        shell: bash
+        run: |
+          set -x
+          curl -v -m 10 -sS -o /dev/null -w "HTTP=%{http_code}\n" \
+            "http://grafana.monitoring.svc.cluster.local/api/health" || true
+      - name: Health check (with org + token if present)
+        shell: bash
+        env:
+          ORG_ID: ${{ vars.GRAFANA_ORG_ID || '1' }}
+        run: |
+          set -x
+          H=(-H "X-Org-Id: ${ORG_ID}")
+          if [ -n "${GRAFANA_API_TOKEN:-}" ]; then H+=(-H "Authorization: Bearer ${GRAFANA_API_TOKEN}"); fi
+          curl -v -m 15 -sS -o /dev/null -w "HTTP=%{http_code}\n" \
+            "${H[@]}" "http://grafana.monitoring.svc.cluster.local/api/health" || true
+      - name: Dump headers for render URL (no download)
+        shell: bash
+        env:
+          ORG_ID: ${{ vars.GRAFANA_ORG_ID || '1' }}
+        run: |
+          set -euo pipefail
+          UID="evidence-prod"; SLUG="evidence-e28093-prod"; PANEL=1
+          H=(-H "X-Org-Id: ${ORG_ID}")
+          if [ -n "${GRAFANA_API_TOKEN:-}" ]; then H+=(-H "Authorization: Bearer ${GRAFANA_API_TOKEN}"); fi
+          URL="http://grafana.monitoring.svc.cluster.local/render/d-solo/${UID}/${SLUG}"
+          echo "URL=$URL"
+          curl -sS -I -G "${H[@]}" "$URL" \
+            --data-urlencode panelId=$PANEL --data-urlencode from=now-30m --data-urlencode to=now || true
+
   call-render-inline:
     runs-on: [self-hosted, k8s-runner]
     steps:


### PR DESCRIPTION
Add a self-hosted diagnostic job to render_manual.yml and expand the composite action logging/retries for Grafana render requests.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

