### PR TITLE
composite: drop unsupported curl retry flag

### DIFF
--- a/.github/actions/render-grafana/action.yml
+++ b/.github/actions/render-grafana/action.yml
@@ -78,7 +78,7 @@ runs:
 
         HTTP=""; CT=""; SIZE=0; SIG=""
         for i in 1 2 3; do
-          HTTP=$(curl -sS -m 60 --retry 2 --retry-delay 2 --retry-all-errors \
+          HTTP=$(curl -sS -m 60 --retry 2 --retry-delay 2 \
             -w "%{http_code}" -G "${AUTH[@]}" -H "X-Org-Id: ${ORG}" \
             "$URL" --data-urlencode panelId="${RENDER_PANEL}" --data-urlencode from="${FROM}" --data-urlencode to="${TO}" \
             -D artifacts/headers.txt -o artifacts/out.png || true)


### PR DESCRIPTION
cURL 7.68 on the runner does not support --retry-all-errors; remove it and rely on --retry/--retry-delay.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

