### PR TITLE
chore(reports): add initial status/decisions for redshift-migration-2026

### DIFF
--- a/reports/projects/redshift-migration-2026/decisions/20251031.md
+++ b/reports/projects/redshift-migration-2026/decisions/20251031.md
@@ -1,0 +1,4 @@
+# Decision Log
+- D-001: テーブル群の型マッピング方針を NUMERIC(p,s) 基本に統一。SUPERは避ける。
+  Reason: BI応答の計画安定性を優先。
+  Impact: docs/projects/redshift-migration-2026/ddl_diff.md 更新、影響テーブル=未算出。

--- a/reports/projects/redshift-migration-2026/status/2025-10-31.md
+++ b/reports/projects/redshift-migration-2026/status/2025-10-31.md
@@ -1,0 +1,5 @@
+status: WARN
+checked_at: 2025-10-31T00:52:15Z
+evidence:
+  - contracts/projects/redshift-migration-2026.yaml
+delta_hint: "DDL差分の型マッピング未確定（DECIMAL精度・ソートキー方針）"


### PR DESCRIPTION
Add initial WARN status and first decision log for project redshift-migration-2026.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
- reports/projects/redshift-migration-2026/decisions/20251031.md
- reports/projects/redshift-migration-2026/status/2025-10-31.md

