### PR TITLE
fix(render): always upload grafana artifacts

### DIFF
--- a/.github/actions/render-grafana/action.yml
+++ b/.github/actions/render-grafana/action.yml
@@ -99,6 +99,7 @@ runs:
           exit 1
         fi
     - name: Upload artifacts
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: grafana-render


### PR DESCRIPTION
Ensure render-grafana composite uploads artifacts even on failure.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

