### PR TITLE
feat(observability): deploy minimal grafana for evidence renders

### DIFF
--- a/infra/k8s/overlays/dev/monitoring/grafana-dashboards-configmap.yaml
+++ b/infra/k8s/overlays/dev/monitoring/grafana-dashboards-configmap.yaml
@@ -50,27 +50,25 @@ data:
       ],
       "templating": { "list": [] }
     }
----
-# Grafana が自動で dashboards/ を読むように、既存 Deployment へ volume をマウント（既存と併用想定）
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: grafana
-  namespace: monitoring
-spec:
-  template:
-    spec:
-      volumes:
-      - name: dashboards
-        configMap:
-          name: grafana-dashboards
-      containers:
-      - name: grafana
-        volumeMounts:
-        - name: dashboards
-          mountPath: /var/lib/grafana/dashboards
-        env:
-        - name: GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH
-          value: /var/lib/grafana/dashboards/vpm-mini-dev-overview.json
-        - name: GF_DASHBOARDS_ENABLE
-          value: "true"
+  evidence-prod.json: |
+    {
+      "uid": "evidence-prod",
+      "title": "Evidence \\u2013 Prod",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "5m",
+      "timezone": "browser",
+      "panels": [
+        {
+          "id": 1,
+          "type": "text",
+          "title": "Daily Evidence Placeholder",
+          "gridPos": { "x": 0, "y": 0, "w": 24, "h": 9 },
+          "options": {
+            "mode": "markdown",
+            "content": "# Evidence\\nPlaceholder panel rendered for tests."
+          }
+        }
+      ],
+      "templating": { "list": [] }
+    }

--- a/infra/k8s/overlays/dev/monitoring/grafana-dashboards-patch.yaml
+++ b/infra/k8s/overlays/dev/monitoring/grafana-dashboards-patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  template:
+    spec:
+      volumes:
+      - name: dashboards
+        configMap:
+          name: grafana-dashboards
+      containers:
+      - name: grafana
+        volumeMounts:
+        - name: dashboards
+          mountPath: /var/lib/grafana/dashboards
+        env:
+        - name: GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH
+          value: /var/lib/grafana/dashboards/vpm-mini-dev-overview.json
+        - name: GF_DASHBOARDS_ENABLE
+          value: "true"

--- a/infra/k8s/overlays/dev/monitoring/grafana.yaml
+++ b/infra/k8s/overlays/dev/monitoring/grafana.yaml
@@ -19,12 +19,19 @@ kind: Deployment
 metadata:
   name: grafana
   namespace: monitoring
+  labels:
+    app: grafana
+    app.kubernetes.io/instance: grafana
+    app.kubernetes.io/name: grafana
 spec:
   replicas: 1
   selector: { matchLabels: { app: grafana } }
   template:
     metadata:
-      labels: { app: grafana }
+      labels:
+        app: grafana
+        app.kubernetes.io/instance: grafana
+        app.kubernetes.io/name: grafana
     spec:
       containers:
       - name: grafana
@@ -53,5 +60,5 @@ spec:
   selector: { app: grafana }
   ports:
   - name: http
-    port: 3000
+    port: 80
     targetPort: 3000

--- a/infra/k8s/overlays/dev/monitoring/kustomization.yaml
+++ b/infra/k8s/overlays/dev/monitoring/kustomization.yaml
@@ -2,7 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - namespace.yaml
+- grafana.yaml
+- grafana-dashboards-configmap.yaml
 - promrule-hello.yaml
 - promrule.yaml
 - servicemonitor-hello.yaml
 - servicemonitor.yaml
+patchesStrategicMerge:
+- grafana-dashboards-patch.yaml


### PR DESCRIPTION
Deploy a minimal Grafana instance with placeholder dashboard so render_manual can produce PNG evidence.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

