### PR TITLE
WS1: single-shot runner (maxReplicas=1)

### DIFF
--- a/.github/actions-runner/hra.yaml
+++ b/.github/actions-runner/hra.yaml
@@ -1,0 +1,16 @@
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: HorizontalRunnerAutoscaler
+metadata:
+  name: vpm-mini-rd-hra
+  namespace: actions
+spec:
+  scaleTargetRef:
+    name: vpm-mini-rd
+  minReplicas: 0
+  maxReplicas: 1
+  metrics:
+    - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
+      repositoryNames:
+        - HirakuArai/vpm-mini
+      scaleUpThreshold: "1"
+      scaleDownThreshold: "0"


### PR DESCRIPTION
Record the HorizontalRunnerAutoscaler manifest with maxReplicas=1 so vpm-mini-rd only scales 0→1→0. The render workflow already carries a concurrency guard, so no YAML change needed there.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

