### PR TITLE
WS3: Self-Cost KPIs on daily card

### DIFF
--- a/.github/workflows/synthesize_decisions.yml
+++ b/.github/workflows/synthesize_decisions.yml
@@ -10,6 +10,9 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
 
       - name: Compute metadata
         id: now
@@ -17,21 +20,75 @@ jobs:
           echo "date=$(date +%F)" >> "$GITHUB_OUTPUT"
           echo "run_id=${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
 
-      - name: Generate decision card (stub)
+      - name: Collect self-cost KPIs
+        id: self_cost
         run: |
-          mkdir -p reports
-          D="${{ steps.now.outputs.date }}"
+          python3 scripts/collect_and_compute.py > self_cost.json
+          cat self_cost.json
           {
-            echo "# Daily Decision — ${D}"
-            echo
-            echo "Status: GREEN（bootstrap）"
-            echo
-            echo "**Today (max 3)**"
-            echo "- なし"
-            echo
-            echo "Evidence: <TBD>"
-            echo "FOOTER: RUN=${{ steps.now.outputs.run_id }} VERIFY=stub"
-          } > "reports/decision_${D}.md"
+            echo "json<<EOF"
+            cat self_cost.json
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate decision card
+        run: |
+          python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+date = os.environ["DATE"]
+run_id = os.environ["RUN_ID"]
+data = {}
+try:
+    with open("self_cost.json", "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except FileNotFoundError:
+    data = {}
+
+def fmt_flag(key: str) -> str:
+    value = data.get(key, -1)
+    if value in (0, 1):
+        return str(value)
+    return "unknown"
+
+runtime = data.get("runtime_minutes", -1)
+runtime_str = str(runtime if isinstance(runtime, int) and runtime >= 0 else "unknown")
+
+lines = [
+    f"# Daily Decision — {date}",
+    "",
+    "Status: GREEN（bootstrap）",
+    "",
+    "**Today (max 3)**",
+    "- なし",
+    "",
+    "**Self-Cost**",
+    f"- external_ip_zero: {fmt_flag('external_ip_zero')}",
+    f"- unused_pds_zero: {fmt_flag('unused_pds_zero')}",
+    f"- runtime_minutes: {runtime_str}",
+    "",
+    "Evidence: <TBD>",
+    f"FOOTER: RUN={run_id} VERIFY=self-cost-stub",
+]
+
+remediation = []
+if data.get("external_ip_zero", 1) == 0:
+    remediation.append("- [ ] Release unused external IPs")
+if data.get("unused_pds_zero", 1) == 0:
+    remediation.append("- [ ] Delete unused PDs")
+if remediation:
+    idx = lines.index("Evidence: <TBD>")
+    lines[idx:idx] = ["", "**Remediation**", *remediation, ""]
+
+path = Path(f"reports/decision_{date}.md")
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+        env:
+          DATE: ${{ steps.now.outputs.date }}
+          RUN_ID: ${{ steps.now.outputs.run_id }}
 
       - name: Create PR
         uses: peter-evans/create-pull-request@v6

--- a/scripts/collect_and_compute.py
+++ b/scripts/collect_and_compute.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Collect lightweight self-cost indicators for daily reporting.
+
+Outputs a JSON object with:
+  external_ip_zero: 1 if there are no unused external IPs, 0 if leftovers, -1 if unknown
+  unused_pds_zero:  1 if there are no unused persistent disks, 0 if leftovers, -1 if unknown
+  runtime_minutes:  integer minutes for the latest render_manual workflow run, -1 if unavailable
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from typing import Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+REPO = os.environ.get("SELF_COST_REPO", "HirakuArai/vpm-mini")
+WORKFLOW_FILE = "render_manual.yml"
+
+
+def run_command(args: list[str]) -> Optional[str]:
+    if not args or shutil.which(args[0]) is None:
+        return None
+    try:
+        result = subprocess.run(
+            args,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    output = result.stdout.strip()
+    return output if output else ""
+
+
+def count_lines(args: list[str]) -> Optional[int]:
+    output = run_command(args)
+    if output is None:
+        return None
+    lines = [line for line in output.splitlines() if line.strip()]
+    return len(lines)
+
+
+def fetch_latest_render_runtime() -> int:
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    url = f"https://api.github.com/repos/{REPO}/actions/workflows/{WORKFLOW_FILE}/runs?per_page=1"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "self-cost-collector",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = Request(url, headers=headers)
+    try:
+        with urlopen(request, timeout=10) as response:
+            payload = json.load(response)
+    except (HTTPError, URLError, json.JSONDecodeError):
+        return -1
+    runs = payload.get("workflow_runs") or []
+    if not runs:
+        return -1
+    run = runs[0]
+    started_at = run.get("run_started_at") or run.get("created_at")
+    completed_at = run.get("updated_at")
+    if not started_at or not completed_at:
+        return -1
+    try:
+        start_dt = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+        end_dt = datetime.fromisoformat(completed_at.replace("Z", "+00:00"))
+    except ValueError:
+        return -1
+    runtime = end_dt - start_dt
+    if runtime.total_seconds() < 0:
+        return -1
+    return int(runtime.total_seconds() // 60)
+
+
+def main() -> int:
+    addr_count = count_lines(
+        [
+            "gcloud",
+            "-q",
+            "compute",
+            "addresses",
+            "list",
+            "--filter=status!=IN_USE",
+            "--format=value(address)",
+        ]
+    )
+    pd_count = count_lines(
+        [
+            "gcloud",
+            "-q",
+            "compute",
+            "disks",
+            "list",
+            "--filter=-users:*",
+            "--format=value(name)",
+        ]
+    )
+    runtime = fetch_latest_render_runtime()
+
+    def as_flag(count: Optional[int]) -> int:
+        if count is None:
+            return -1
+        return 1 if count == 0 else 0
+
+    data = {
+        "external_ip_zero": as_flag(addr_count),
+        "unused_pds_zero": as_flag(pd_count),
+        "runtime_minutes": runtime,
+        "counts": {
+            "unused_external_ips": addr_count if addr_count is not None else -1,
+            "unused_pds": pd_count if pd_count is not None else -1,
+        },
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    json.dump(data, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Collect daily self-cost metrics and surface them in the decision card. Includes {
  "external_ip_zero": 1,
  "unused_pds_zero": 0,
  "runtime_minutes": 0,
  "counts": {
    "unused_external_ips": 0,
    "unused_pds": 2
  },
  "generated_at": "2025-11-04T20:47:39.819118+00:00"
} and renders external_ip_zero / unused_pds_zero / runtime_minutes with remediation prompts when leftovers remain.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

