### PR TITLE
fix: kubectl scale uses deployment resource

### DIFF
--- a/.github/actions/render-grafana/action.yml
+++ b/.github/actions/render-grafana/action.yml
@@ -66,8 +66,8 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        ./kubectl -n monitoring scale deploy/grafana --replicas=1
-        ./kubectl -n monitoring rollout status deploy/grafana --timeout=120s
+        ./kubectl --namespace monitoring scale deployment/grafana --replicas=1
+        ./kubectl --namespace monitoring rollout status deployment/grafana --timeout=120s
     - name: Render PNG
       shell: bash
       env:
@@ -124,4 +124,4 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        ./kubectl -n monitoring scale deploy/grafana --replicas=0
+        ./kubectl --namespace monitoring scale deployment/grafana --replicas=0


### PR DESCRIPTION
Use `kubectl --namespace monitoring scale deployment/grafana` so the CLI recognizes the resource after downloading kubectl inside the composite.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

