### PR TITLE
fix: patch grafana replicas via kubectl

### DIFF
--- a/.github/actions/render-grafana/action.yml
+++ b/.github/actions/render-grafana/action.yml
@@ -66,7 +66,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        ./kubectl --namespace monitoring scale deployment grafana --replicas=1
+        ./kubectl --namespace monitoring patch deployment grafana --type merge -p '{"spec":{"replicas":1}}'
         ./kubectl --namespace monitoring rollout status deployment/grafana --timeout=120s
     - name: Render PNG
       shell: bash
@@ -124,4 +124,4 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        ./kubectl --namespace monitoring scale deployment grafana --replicas=0
+        ./kubectl --namespace monitoring patch deployment grafana --type merge -p '{"spec":{"replicas":0}}'


### PR DESCRIPTION
Replace `kubectl scale` with a merge patch so the downloaded kubectl updates deployment/grafana correctly in ARC runners.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

