### PR TITLE
fix: allow actions runner to patch grafana

### DIFF
--- a/infra/k8s/base/monitoring/role-scale-grafana.yaml
+++ b/infra/k8s/base/monitoring/role-scale-grafana.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: monitoring
 rules:
   - apiGroups: ["apps"]
-    resources: ["deployments/scale"]
+    resources:
+      - deployments
+      - deployments/scale
     verbs: ["get", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Grant apps/v1 deployments in the monitoring namespace so the composite's kubectl patch has permission to adjust replicas.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

