### PR TITLE
chore: extend grafana rollout timeout

### DIFF
--- a/.github/actions/render-grafana/action.yml
+++ b/.github/actions/render-grafana/action.yml
@@ -67,7 +67,7 @@ runs:
       run: |
         set -euo pipefail
         ./kubectl --namespace monitoring patch deployment grafana --type merge -p '{"spec":{"replicas":1}}'
-        ./kubectl --namespace monitoring rollout status deployment/grafana --timeout=120s
+        ./kubectl --namespace monitoring rollout status deployment/grafana --timeout=300s
     - name: Render PNG
       shell: bash
       env:


### PR DESCRIPTION
Give Grafana up to 5 minutes to become Ready after scaling before we proceed with rendering.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

