### PR TITLE
fix: grant watch/list for grafana rollout

### DIFF
--- a/infra/k8s/base/monitoring/role-scale-grafana.yaml
+++ b/infra/k8s/base/monitoring/role-scale-grafana.yaml
@@ -8,7 +8,7 @@ rules:
     resources:
       - deployments
       - deployments/scale
-    verbs: ["get", "update", "patch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Allow the runner service account to list and watch the Grafana deployment so `kubectl rollout status` can observe readiness.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

