### PR TITLE
hotfix: decision_manual permissions

### DIFF
--- a/.github/workflows/decision_manual.yml
+++ b/.github/workflows/decision_manual.yml
@@ -3,6 +3,12 @@ name: Decision Manual
 on:
   workflow_dispatch: {}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   trigger:
+    permissions: inherit
     uses: ./.github/workflows/synthesize_decisions.yml
+    secrets: inherit  # pragma: allowlist secret


### PR DESCRIPTION
Grant contents/pull-requests: write and permissions: inherit so the reusable can open PRs.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

