### PR TITLE
hotfix: decision_manual permissions#2

### DIFF
--- a/.github/workflows/decision_manual.yml
+++ b/.github/workflows/decision_manual.yml
@@ -9,6 +9,8 @@ permissions:
 
 jobs:
   trigger:
-    permissions: inherit
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ./.github/workflows/synthesize_decisions.yml
     secrets: inherit  # pragma: allowlist secret


### PR DESCRIPTION
Set explicit contents/pull-requests write permissions on the wrapper job so the reusable workflow inherits the required scope.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

