### PR TITLE
fix: Decision Manual minimal + synth callable

### DIFF
--- a/.github/workflows/decision_manual.yml
+++ b/.github/workflows/decision_manual.yml
@@ -1,16 +1,10 @@
 name: Decision Manual
-
 on:
   workflow_dispatch: {}
-
 permissions:
   contents: write
   pull-requests: write
-
 jobs:
-  trigger:
-    permissions:
-      contents: write
-      pull-requests: write
+  call:
     uses: ./.github/workflows/synthesize_decisions.yml
     secrets: inherit  # pragma: allowlist secret


### PR DESCRIPTION
Wrapper minimized (top-level perms only; job uses+secrets only). synth exposes workflow_call & workflow_dispatch.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

