### PR TITLE
fix: Decision Manual passes id-token

### DIFF
--- a/.github/workflows/decision_manual.yml
+++ b/.github/workflows/decision_manual.yml
@@ -4,6 +4,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 jobs:
   call:
     uses: ./.github/workflows/synthesize_decisions.yml


### PR DESCRIPTION
Allow the reusable synth workflow to obtain an OIDC token via inherited permissions.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

