### PR TITLE
fix: synthesize_decisions WIF bootstrap (final)

### DIFF
--- a/.github/workflows/synthesize_decisions.yml
+++ b/.github/workflows/synthesize_decisions.yml
@@ -12,8 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Auth to Google Cloud (WIF if provided)
-        if: ${{ secrets.GCP_WIF_PROVIDER != '' }}
+      - name: Auth to Google Cloud (WIF)
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
@@ -23,6 +22,9 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Deps (jq/python3)
+        run: sudo apt-get update && sudo apt-get install -y jq python3 || true
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Ensure auth@v2 + setup-gcloud + deps run before collecting metrics for planner compatibility.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

