### PR TITLE
fix: chatops-ask remove temperature

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -29,7 +29,6 @@ jobs:
           jq -n --arg sys "$(cat out/sys.txt)" --arg usr "$(cat out/ctx.txt)" '{
             model:"gpt-5",
             response_format:{type:"json_object"},
-            temperature:0.2,
             messages:[{role:"system",content:$sys},{role:"user",content:$usr}]
           }' > out/req.json
           curl -sS https://api.openai.com/v1/chat/completions \


### PR DESCRIPTION
The current model only supports default temperature=1.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

