### PR TITLE
add: ask-entry workflow (reply+save PR)

### DIFF
--- a/.github/workflows/ask-entry.yml
+++ b/.github/workflows/ask-entry.yml
@@ -1,0 +1,98 @@
+name: ask-entry
+on:
+  workflow_dispatch:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened]
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  ask:
+    # issue_comment は必ず実行、issues は ask ラベル検知、dispatch も実行
+    if: >
+      (github.event_name == 'issue_comment') ||
+      (github.event_name == 'issues' && contains(toJson(github.event.issue.labels), '"name":"ask"')) ||
+      (github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build prompt
+        run: |
+          mkdir -p out reports/ask
+          ISSUE_BODY="${{ github.event_name == 'issue_comment' && github.event.comment.body || github.event.issue.body }}"
+          printf '%s\n' "$(cat tools/prompts/llm_relay_system.md)" > out/sys.txt
+          printf 'context_header: repo=vpm-mini / branch=main / phase=Phase 2\n' > out/ctx.txt
+          printf 'QUESTION\n%s\n' "$(echo "$ISSUE_BODY")" >> out/ctx.txt
+
+      - name: Call OpenAI (gpt-5; raw & strip fences)
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -e
+          jq -n --arg sys "$(cat out/sys.txt)" --arg usr "$(cat out/ctx.txt)" '{
+            model:"gpt-5", response_format:{type:"json_object"},
+            messages:[{role:"system",content:$sys},{role:"user",content:$usr}]
+          }' > out/req.json
+          curl -sS https://api.openai.com/v1/chat/completions \
+            -H "Authorization: Bearer ${OPENAI_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d @out/req.json | tee out/raw.json >/div/null || true
+          jq -r '.choices[0].message.content // ""' out/raw.json > out/u_contract.txt
+          if [ ! -s out/u_contract.txt ]; then
+            echo '{"typing":"no-content","context_header":"'"$(sed -n '1s/^context_header: //p' out/ctx.txt)"'","understanding":{"C":"","G":"","delta":"","assumptions":[],"unknowns":[]},"plan":[],"acceptance":[],"citations":[],"confidence":0.0}' > out/u_contract.json
+          else
+            awk 'NR==1{sub(/^```(json)?[[:space:]]*/,"")} {buf=buf $0 ORS} END{ sub(/```[[:space:]]*[\r\n]*$/,"",buf); printf "%s", buf }' out/u_contract.txt > out/u_contract.json
+          fi
+
+      - name: Normalize + Coerce (minimal schema)
+        run: |
+          CH=$(sed -n '1s/^context_header: //p' out/ctx.txt)
+          jq --arg ch "$CH" '
+            (.context_header //= $ch) | (.typing //= "plan要約") | (.confidence //= 0.5) |
+            (.understanding //= {}) |
+            (.understanding.C //= "") | (.understanding.G //= "") |
+            (.understanding.delta //= "") |
+            (.understanding.assumptions //= []) | (.understanding.unknowns //= []) |
+            (.plan |= ( if type=="string" then
+                          [ {id:"p1", desc: ., commands:[], evidence:[], risks:[]} ]
+                        elif type=="array" then
+                          [ range(0; length) as $i | .[$i]
+                            | ( if type=="string"
+                                  then {id:("p"+(($i+1)|tostring)), desc:., commands:[], evidence:[], risks:[]}
+                                  elif type=="object" then . else . end ) ]
+                        else [] end )) |
+            (.acceptance |= ( if type=="string" then [.] elif type=="array" then . else [] end )) |
+            (.citations |= ( if type=="string" then [ {path:., lines:""} ]
+                             elif type=="array" then [ .[] | ( if type=="string" then {path:., lines:""} else . end ) ]
+                             elif type=="object" then [.] else [] end ))
+          ' out/u_contract.json > out/u_contract.norm.json
+          mv out/u_contract.norm.json out/u_contract.json
+
+      - name: Comment back JSON (always)
+        env: { GH_TOKEN: ${{ github.token }} }
+        run: |
+          body="\`\`\`json\n$(cat out/u_contract.json)\n\`\`\`"
+          num=${{ github.event.issue.number || github.event.pull_request.number }}
+          gh api repos/${{ github.repository }}/issues/$num/comments -f body="$body" || true
+
+      - name: Open Save-PR (always)
+        env: { GH_TOKEN: ${{ github.token }} }
+        run: |
+          set -e
+          ts=$(date -u +%Y%m%dT%H%M%SZ)
+          mkdir -p reports/ask
+          cp out/u_contract.json "reports/ask/ask_${ts}.json"
+          git config user.email "bot@users.noreply.github.com"
+          git config user.name  "github-actions[bot]"
+          git checkout -b "ask/store/${ts}"
+          git add reports/ask/ask_${ts}.json
+          git commit -m "ask: persist u_contract (${ts})"
+          git push -u origin "ask/store/${ts}"
+          gh pr create --base main --head "ask/store/${ts}" \
+            -t "ask: persist u_contract (${ts})" -b "Persisted from ask-entry." \
+            --label ask --label evidence || true


### PR DESCRIPTION
Separate entry to avoid stale registration; robust triggers; PR save.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

