### PR TITLE
Evidence: P2-1 GREEN (control-plane READY)

### DIFF
--- a/reports/p2_boot_20251109T201707.md
+++ b/reports/p2_boot_20251109T201707.md
@@ -1,0 +1,17 @@
+# P2-1 bootstrap (2025-11-09T201707+0000)
+## knative-serving
+NAME                                      READY   STATUS    RESTARTS   AGE    IP           NODE                     NOMINATED NODE   READINESS GATES
+activator-76dfb9f767-hdfct                1/1     Running   0          107s   10.244.0.4   vpm-mini-control-plane   <none>           <none>
+autoscaler-77f5c4668d-fthtj               1/1     Running   0          107s   10.244.0.8   vpm-mini-control-plane   <none>           <none>
+controller-79f47f6984-ccbmz               1/1     Running   0          107s   10.244.0.6   vpm-mini-control-plane   <none>           <none>
+net-kourier-controller-666c5cf64b-jj8gx   1/1     Running   0          105s   10.244.0.2   vpm-mini-control-plane   <none>           <none>
+webhook-c8f58f6f7-xg9x5                   1/1     Running   0          107s   10.244.0.3   vpm-mini-control-plane   <none>           <none>
+
+## kourier-system
+NAME                                      READY   STATUS    RESTARTS   AGE    IP           NODE                     NOMINATED NODE   READINESS GATES
+3scale-kourier-gateway-5bb4856d57-kt79g   1/1     Running   0          105s   10.244.0.9   vpm-mini-control-plane   <none>           <none>
+
+## services
+NAME               TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                      AGE    SELECTOR
+kourier            LoadBalancer   10.96.140.160   <pending>     80:30251/TCP,443:32636/TCP   106s   app=3scale-kourier-gateway
+kourier-internal   ClusterIP      10.96.235.134   <none>        80/TCP,443/TCP               106s   app=3scale-kourier-gateway


### PR DESCRIPTION
Bootstrap on kind v1.31.x succeeded.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
- reports/p2_boot_20251109T201707.md

