### PR TITLE
CI: fix GHCR lowercase owner for metrics-echo

### DIFF
--- a/.github/workflows/build-metrics-echo.yml
+++ b/.github/workflows/build-metrics-echo.yml
@@ -11,20 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      # 👇 リポジトリオーナーを小文字化（GHCRは小文字必須）
       - id: lower
         name: Lowercase owner
-        run: |
-          echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
-
+        run: echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
       - name: Login GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ steps.lower.outputs.owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build & Push :dev
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
Docker/OCI requires lowercase repository names.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

