### PR TITLE
Feat: metrics-echo READY=True (dev)

### DIFF
--- a/infra/k8s/overlays/dev/metrics-echo-ksvc.yaml
+++ b/infra/k8s/overlays/dev/metrics-echo-ksvc.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: ghcr.io/HirakuArai/metrics-echo:dev
+      - image: ghcr.io/hirakuarai/metrics-echo:dev
         env: [{ name: TARGET, value: "vpm-mini" }]

--- a/reports/metrics_echo_test.txt
+++ b/reports/metrics_echo_test.txt
@@ -1,0 +1,1 @@
+metrics-echo ok ts=1762739675 target=vpm-mini


### PR DESCRIPTION
KService deploy + curl 証跡（reports/metrics_echo_test.txt）と GHCR 参照小文字化を反映

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
- reports/metrics_echo_test.txt

