### PR TITLE
Fix: thinker add plan only

### DIFF
--- a/reports/think/plan_20251110T045616.md
+++ b/reports/think/plan_20251110T045616.md
@@ -1,0 +1,11 @@
+# Think Plan
+
+- source_ask: `reports/ask/ask_2025-11-09T1900.json`
+- issue: #571
+- dry_run: True
+
+## understanding
+received '/ask'
+
+## plan.commands
+- (no commands)

--- a/reports/think/plan_20251110T045633.md
+++ b/reports/think/plan_20251110T045633.md
@@ -1,0 +1,11 @@
+# Think Plan
+
+- source_ask: `reports/ask/ask_2025-11-09T1900.json`
+- issue: #571
+- dry_run: True
+
+## understanding
+received '/ask'
+
+## plan.commands
+- (no commands)


### PR DESCRIPTION
Stop adding think_*.json; .gitignore-friendly.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
- reports/think/plan_20251110T045616.md
- reports/think/plan_20251110T045633.md

