### PR TITLE
Fix: Thinker add plan only

### DIFF
--- a/tools/think/thinker.py
+++ b/tools/think/thinker.py
@@ -99,7 +99,7 @@ def main():
     # 3) ブランチ作成→コミット→Push→ドラフトPR
     sh("git fetch origin --quiet")
     sh(f"git switch -c {branch}")
-    sh(f"git add {os.path.relpath(plan_md, ROOT)} {os.path.relpath(think_json, ROOT)}")
+    sh(f'git add {os.path.relpath(plan_md, ROOT)}')
     sh(f'git commit -m "think: plan {ts} (draft via thinker)"')
     sh("git push -u origin HEAD")
 


### PR DESCRIPTION
Stop adding think_*.json (ignored by .gitignore); unblock draft PR creation.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

