### PR TITLE
Fix: thinker --execute uses store_true

### DIFF
--- a/tools/think/thinker.py
+++ b/tools/think/thinker.py
@@ -107,7 +107,7 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--issue", help="numeric issue id to prefer from reports/ask")
     ap.add_argument("--dry-run", action="store_true", help="do not execute external commands")
-    ap.add_argument("--execute", action="is_true", default=False)
+    ap.add_argument("--execute", action="store_true", default=False)
     args = ap.parse_args()
 
     # discover ask JSON


### PR DESCRIPTION
Replace invalid argparse action=is_true with action=store_true.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

