### PR TITLE
Fix: thinker PR URL parse (url→out)

### DIFF
--- a/tools/think/thinker.py
+++ b/tools/think/thinker.py
@@ -173,7 +173,7 @@ def main():
         "-H", branch,
         "-B", "main"
     ], capture=True).strip()
-pr_number = (url.rsplit("/", 1)[-1].lstrip("#") if url else "")
+pr_number = (out.rsplit("/", 1)[-1].lstrip("#") if out else "")
 if not pr_number:
     # 最後の手段: ヘッドブランチからPR番号を引く
     pr_number = run([


### PR DESCRIPTION
Use 'out' variable when parsing gh pr create output.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

