### PR TITLE
Fix: ask-entry normalization tolerates string/null .understanding

### DIFF
--- a/.github/workflows/ask-entry.yml
+++ b/.github/workflows/ask-entry.yml
@@ -84,12 +84,17 @@ jobs:
             (.context_header //= $ch)
             | (.typing //= "plan要約")
             | (.confidence //= 0.5)
-            | (.understanding //= {})
-            | (.understanding.C //= "")
-            | (.understanding.G //= "")
-            | (.understanding.delta //= "")
-            | (.understanding.assumptions //= [])
-            | (.understanding.unknowns //= [])
+            | (.understanding |=
+                ( if type=="string" then
+                    {C:., G:"", delta:"", assumptions:[], unknowns:[]}
+                  elif type=="null" then
+                    {C:"", G:"", delta:"", assumptions:[], unknowns:[]}
+                  elif type=="object" then
+                    (.C //= "") | (.G //= "") | (.delta //= "")
+                    | (.assumptions //= []) | (.unknowns //= [])
+                  else
+                    {C:"", G:"", delta:"", assumptions:[], unknowns:[]}
+                  end ))
             | (.plan |= ( if type=="string" then
                             [ {id:"p1", desc:., commands:[], evidence:[], risks:[]} ]
                           elif type=="array" then


### PR DESCRIPTION
## Summary
- normalize `.understanding` when the model returns string/null/other to avoid jq indexing errors
- preserve existing plan/acceptance/citation coercions

## Validation
- python3 - <<'PY' ... yaml.safe_load(.github/workflows/ask-entry.yml)
- actionlint .github/workflows/ask-entry.yml (pre-existing warnings about ISSUE_BODY usage remain)

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

