### PR TITLE
Fix: think executor allow kubectl dry-run commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ reports/*.png
 reports/mna_update_*.md
 reports/icr_history.csv
 .DS_Store
-reports/think/*.json
+reports/think/*
+!reports/think/.gitkeep


### PR DESCRIPTION
## Summary
- restrict kubectl allowlist to get/describe/wait and scan argv left to right
- enforce --request-timeout=30s for wait and cap subprocess timeout at 40s
- ignore all reports/think artifacts so dry-run logs don't dirty the tree

## Testing
- python3 tools/think/executor.py --commands "kubectl -n kourier-system get svc kourier" --dry-run
- python3 tools/think/executor.py --commands "kubectl wait pod/foo --for=condition=Ready" --dry-run

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

