### PR TITLE
CI: guard evidence-only auto-approve

### DIFF
--- a/.github/workflows/auto_approve_evidence.yml
+++ b/.github/workflows/auto_approve_evidence.yml
@@ -1,0 +1,41 @@
+name: Auto-approve Evidence PRs
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - 'reports/ask/**'
+      - 'codex/inbox/**'
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  guard-and-approve:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            evidence:
+              - 'reports/ask/**'
+              - 'codex/inbox/**'
+            code:
+              - '**'
+              - '!reports/ask/**'
+              - '!codex/inbox/**'
+
+      - name: Approve evidence-only PR
+        if: >
+          startsWith(github.head_ref, 'ask/store/')
+          && contains(toJson(github.event.pull_request.labels), 'evidence')
+          && steps.filter.outputs.evidence == 'true'
+          && steps.filter.outputs.code == 'false'
+        uses: peter-evans/approve-pull-request@v5
+        with:
+          pull-request-number: ${{ github.event.pull_request.number }}
+          review-message: "Auto-approving evidence-only PR."


### PR DESCRIPTION
Add `.github/workflows/auto_approve_evidence.yml` to auto-approve evidence-only PRs.

**Policy**
- Branch: `ask/store/**`
- Label: `evidence`
- Paths: `reports/ask/**`, `codex/inbox/**` only
- Code-mixed PRs are blocked via paths-filter

**DoD**
- An evidence-only PR is automatically approved
- A PR with any code file is not approved

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

