### PR TITLE
CI: guard evidence auto-approve (robust head_ref/label check)

### DIFF
--- a/.github/workflows/auto_approve_evidence.yml
+++ b/.github/workflows/auto_approve_evidence.yml
@@ -5,6 +5,11 @@ on:
     paths:
       - 'reports/ask/**'
       - 'codex/inbox/**'
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - 'reports/ask/**'
+      - 'codex/inbox/**'
 permissions:
   pull-requests: write
   contents: read
@@ -29,10 +34,15 @@ jobs:
               - '!reports/ask/**'
               - '!codex/inbox/**'
 
+      - name: Compute head ref
+        id: vars
+        shell: bash
+        run: echo "head_ref=${{ github.head_ref || github.event.pull_request.head.ref || '' }}" >> $GITHUB_OUTPUT
+
       - name: Approve evidence-only PR
         if: >
-          startsWith(github.head_ref, 'ask/store/')
-          && contains(toJson(github.event.pull_request.labels), 'evidence')
+          startsWith(steps.vars.outputs.head_ref, 'ask/store/')
+          && contains(toJson(github.event.pull_request.labels), '"name":"evidence"')
           && steps.filter.outputs.evidence == 'true'
           && steps.filter.outputs.code == 'false'
         uses: peter-evans/approve-pull-request@v5


### PR DESCRIPTION
Harden the guard workflow to compute head_ref robustly and check label JSON strictly.

- Add pull_request_target to ensure labels event triggers in forks-safe way (paths limited).
- Compute head_ref via output fallback (PR events variants).
- Check label via JSON text to avoid substring false positive.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

