### PR TITLE
CI: auto_approve_evidence v2.2 (labeled target + robust detection)

### DIFF
--- a/.github/workflows/auto_approve_evidence.yml
+++ b/.github/workflows/auto_approve_evidence.yml
@@ -1,51 +1,58 @@
-name: Auto-approve Evidence PRs
+name: Auto-approve Evidence PRs (v2.2)
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
-    paths:
-      - 'reports/ask/**'
-      - 'codex/inbox/**'
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled]
-    paths:
-      - 'reports/ask/**'
-      - 'codex/inbox/**'
+    types: [labeled, synchronize, opened]
 permissions:
   pull-requests: write
   contents: read
 
 jobs:
-  guard-and-approve:
+  approve-if-evidence-only:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v4
-
-      - id: filter
-        uses: dorny/paths-filter@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          filters: |
-            evidence:
-              - 'reports/ask/**'
-              - 'codex/inbox/**'
-            code:
-              - '**'
-              - '!reports/ask/**'
-              - '!codex/inbox/**'
-
       - name: Compute head ref
         id: vars
         shell: bash
-        run: echo "head_ref=${{ github.head_ref || github.event.pull_request.head.ref || '' }}" >> $GITHUB_OUTPUT
+        run: echo "head_ref=${{ github.event.pull_request.head.ref || github.head_ref || '' }}" >> $GITHUB_OUTPUT
 
-      - name: Approve evidence-only PR
-        if: >
-          startsWith(steps.vars.outputs.head_ref, 'ask/store/')
-          && contains(toJson(github.event.pull_request.labels), '"name":"evidence"')
-          && steps.filter.outputs.evidence == 'true'
-          && steps.filter.outputs.code == 'false'
-        uses: peter-evans/approve-pull-request@v5
+      - name: Fetch changed files (base vs head)
+        id: files
+        uses: tj-actions/changed-files@v44
         with:
-          pull-request-number: ${{ github.event.pull_request.number }}
-          review-message: "Auto-approving evidence-only PR."
+          token: ${{ secrets.GITHUB_TOKEN }}
+          since_last_remote_commit: false
+
+      - name: Decide evidence-only
+        id: decide
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const headRef = '${{ steps.vars.outputs.head_ref }}';
+            const labels = pr.labels.map(l=>l.name);
+            const changed = (process.env.CHANGED || '').split('
+').filter(Boolean);
+            core.info(`headRef=${headRef}`);
+            core.info(`labels=${labels.join(',')}`);
+            core.info(`changed-count=${changed.length}`);
+            const onlyEvidence = changed.length > 0 && changed.every(p => p.startsWith('reports/ask/') || p.startsWith('codex/inbox/'));
+            const ok = headRef.startsWith('ask/store/') && labels.includes('evidence') && onlyEvidence;
+            core.setOutput('ok', ok ? 'true':'false');
+          env:
+            CHANGED: ${{ steps.files.outputs.all_changed_files }}
+
+      - name: Approve via API
+        if: steps.decide.outputs.ok == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            await github.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              event: 'APPROVE',
+              body: 'Auto-approving evidence-only PR (v2.2).'
+            });


### PR DESCRIPTION
Switch to pull_request_target(labeled|synchronize|opened) and use changed-files + github-script to strictly decide evidence-only, then approve via API.

This should fix failing runs on #660 and similar PRs.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

