### PR TITLE
CI: auto_approve_evidence v2.3 (API-based decide + approve)

### DIFF
--- a/.github/workflows/auto_approve_evidence.yml
+++ b/.github/workflows/auto_approve_evidence.yml
@@ -1,4 +1,4 @@
-name: Auto-approve Evidence PRs (v2.2)
+name: Auto-approve Evidence PRs (v2.3)
 on:
   pull_request_target:
     types: [labeled, synchronize, opened]
@@ -10,37 +10,28 @@ jobs:
   approve-if-evidence-only:
     runs-on: ubuntu-latest
     steps:
-      - name: Compute head ref
-        id: vars
-        shell: bash
-        run: echo "head_ref=${{ github.event.pull_request.head.ref || github.head_ref || '' }}" >> $GITHUB_OUTPUT
-
-      - name: Fetch changed files (base vs head)
-        id: files
-        uses: tj-actions/changed-files@v44
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          since_last_remote_commit: false
-
-      - name: Decide evidence-only
+      - name: Decide evidence-only via API (debug-friendly)
         id: decide
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr = context.payload.pull_request;
-            const headRef = '${{ steps.vars.outputs.head_ref }}';
-            const labels = pr.labels.map(l=>l.name);
-            const changed = (process.env.CHANGED || '').split('
-').filter(Boolean);
+            const headRef = (pr && pr.head && pr.head.ref) || '';
+            const labels = (pr && pr.labels ? pr.labels.map(l=>l.name) : []);
+            const files = await github.paginate(github.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100
+            });
+            const paths = files.map(f=>f.filename);
             core.info(`headRef=${headRef}`);
             core.info(`labels=${labels.join(',')}`);
-            core.info(`changed-count=${changed.length}`);
-            const onlyEvidence = changed.length > 0 && changed.every(p => p.startsWith('reports/ask/') || p.startsWith('codex/inbox/'));
+            core.info(`changed=${paths.length} -> ${paths.join('|')}`);
+            const onlyEvidence = paths.length > 0 && paths.every(p => p.startsWith('reports/ask/') || p.startsWith('codex/inbox/'))
             const ok = headRef.startsWith('ask/store/') && labels.includes('evidence') && onlyEvidence;
-            core.setOutput('ok', ok ? 'true':'false');
-          env:
-            CHANGED: ${{ steps.files.outputs.all_changed_files }}
+            core.setOutput('ok', ok ? 'true' : 'false');
 
       - name: Approve via API
         if: steps.decide.outputs.ok == 'true'
@@ -54,5 +45,5 @@ jobs:
               repo: context.repo.repo,
               pull_number: pr.number,
               event: 'APPROVE',
-              body: 'Auto-approving evidence-only PR (v2.2).'
+              body: 'Auto-approving evidence-only PR (v2.3).'
             });


### PR DESCRIPTION
Use pull_request_target with API-based files+labels inspection and direct Approve review. Adds rich debug logs (headRef/labels/changed files). Should fix failing approve on #660/#662 and untriggered #664.