### PR TITLE
CI: auto_approve_evidence v2.3b (resolve conflicts; API-based decide+approve)

### DIFF
--- a/.github/workflows/auto_approve_evidence.yml
+++ b/.github/workflows/auto_approve_evidence.yml
@@ -1,4 +1,4 @@
-name: Auto-approve Evidence PRs (v2.2)
+name: Auto-approve Evidence PRs (v2.3)
 on:
   pull_request_target:
     types: [labeled, synchronize, opened]
@@ -10,37 +10,23 @@ jobs:
   approve-if-evidence-only:
     runs-on: ubuntu-latest
     steps:
-      - name: Compute head ref
-        id: vars
-        shell: bash
-        run: echo "head_ref=${{ github.event.pull_request.head.ref || github.head_ref || '' }}" >> $GITHUB_OUTPUT
-
-      - name: Fetch changed files (base vs head)
-        id: files
-        uses: tj-actions/changed-files@v44
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          since_last_remote_commit: false
-
-      - name: Decide evidence-only
+      - name: Decide evidence-only via API (debug-friendly)
         id: decide
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr = context.payload.pull_request;
-            const headRef = '${{ steps.vars.outputs.head_ref }}';
-            const labels = pr.labels.map(l=>l.name);
-            const changed = (process.env.CHANGED || '').split('
-').filter(Boolean);
+            const headRef = (pr && pr.head && pr.head.ref) || '';
+            const labels = (pr && pr.labels ? pr.labels.map(l=>l.name) : []);
+            const files = await github.paginate(github.pulls.listFiles, { owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.number, per_page: 100 });
+            const paths = files.map(f=>f.filename);
             core.info(`headRef=${headRef}`);
             core.info(`labels=${labels.join(',')}`);
-            core.info(`changed-count=${changed.length}`);
-            const onlyEvidence = changed.length > 0 && changed.every(p => p.startsWith('reports/ask/') || p.startsWith('codex/inbox/'));
+            core.info(`changed=${paths.length} -> ${paths.join('|')}`);
+            const onlyEvidence = paths.length > 0 && paths.every(p => p.startsWith('reports/ask/') || p.startsWith('codex/inbox/'));
             const ok = headRef.startsWith('ask/store/') && labels.includes('evidence') && onlyEvidence;
-            core.setOutput('ok', ok ? 'true':'false');
-          env:
-            CHANGED: ${{ steps.files.outputs.all_changed_files }}
+            core.setOutput('ok', ok ? 'true' : 'false');
 
       - name: Approve via API
         if: steps.decide.outputs.ok == 'true'
@@ -49,10 +35,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr = context.payload.pull_request;
-            await github.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr.number,
-              event: 'APPROVE',
-              body: 'Auto-approving evidence-only PR (v2.2).'
-            });
+            await github.pulls.createReview({ owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.number, event: 'APPROVE', body: 'Auto-approving evidence-only PR (v2.3).' });


### PR DESCRIPTION
Rebase-free patch: replace workflow with API-based decide+approve (no checkout; files+labels via API). This avoids the conflict shown on #665 and should pass required checks.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

