### PR TITLE
CI: enforce heavy checks for code PRs (skip on evidence-only)

### DIFF
--- a/.github/workflows/code_checks_enforcer.yml
+++ b/.github/workflows/code_checks_enforcer.yml
@@ -1,0 +1,52 @@
+name: code_checks_enforcer (non-evidence PRs must run heavy checks)
+on:
+  pull_request_target:
+    types: [opened, synchronize, labeled, reopened]
+permissions:
+  contents: read
+  checks: read
+  statuses: read
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide evidence-only via API
+        id: decide
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const headRef = (pr && pr.head && pr.head.ref) || '';
+            const labels = (pr && pr.labels ? pr.labels.map(l=>l.name) : []);
+            const files = await github.paginate(github.pulls.listFiles, { owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.number, per_page: 100 });
+            const paths = files.map(f=>f.filename);
+            const onlyEvidence = paths.length > 0 && paths.every(p => p.startsWith('reports/ask/') || p.startsWith('codex/inbox/'));
+            const okEvidence = headRef.startsWith('ask/store/') || labels.includes('evidence') || onlyEvidence;
+            core.info(`evidence_decide: headRef=${headRef} labels=${labels.join(',')} paths=${paths.length}`);
+            core.setOutput('is_evidence', okEvidence ? 'true' : 'false');
+      - name: Enforce heavy checks for code PRs
+        if: steps.decide.outputs.is_evidence != 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const ref = pr.head.sha;
+            const required = ['test-and-artifacts', 'knative-ready', 'k8s-validate'];
+            const { data: status } = await github.repos.getCombinedStatusForRef({ owner: context.repo.owner, repo: context.repo.repo, ref });
+            const contexts = new Map(status.statuses.map(s => [s.context, s.state]));
+            // Also check checks API (GitHub Apps checks)
+            const checks = await github.checks.listForRef({ owner: context.repo.owner, repo: context.repo.repo, ref, per_page: 100 });
+            for (const c of checks.data.check_runs) { contexts.set(c.name, c.conclusion || c.status); }
+            const missing = [];
+            for (const r of required) {
+              const v = contexts.get(r);
+              if (!v || !(v === 'success' || v === 'completed' || v === 'neutral')) missing.push(r);
+            }
+            if (missing.length) {
+              core.setFailed(`Missing or failing required heavy checks for code PR: ${missing.join(', ')}`);
+            } else {
+              core.info('All required heavy checks present for code PR.');
+            }


### PR DESCRIPTION
Add `.github/workflows/code_checks_enforcer.yml` that decides evidence-only via API and:
- skips for evidence PRs (ask/store, label=evidence, or paths under reports/ask/** or codex/inbox/**)
- **fails** if heavy checks (test-and-artifacts / knative-ready / k8s-validate) are missing on code PRs

This emulates the Code lane while Rulesets Conditions UI is unavailable.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

