### PR TITLE
CI (enforcer): skip when PR is CI-labeled (ci/runner)

### DIFF
--- a/.github/workflows/code_checks_enforcer.yml
+++ b/.github/workflows/code_checks_enforcer.yml
@@ -22,17 +22,19 @@ jobs:
             const labels = (pr && pr.labels ? pr.labels.map(l=>l.name) : []);
             const files = await github.paginate(github.pulls.listFiles, { owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.number, per_page: 100 });
             const paths = files.map(f=>f.filename);
-            const onlyEvidence = paths.length > 0 && paths.every(p => p.startsWith('reports/ask/') || p.startsWith('codex/inbox/'));
+            const onlyEvidence = paths.length > 0 && paths.every(p => p.startsWith('reports/ask/') || p.startsWith('codex/inbox/'))
             const isEvidence = headRef.startsWith('ask/store/') || labels.includes('evidence') || onlyEvidence;
             const isCIOnly = paths.length > 0 && paths.every(p => p.startsWith('.github/'));
-            core.info(`enforcer decide: isEvidence=${isEvidence} isCIOnly=${isCIOnly} headRef=${headRef} labels=${labels.join(',')} paths=${paths.length}`);
+            const isCILabel = labels.includes('ci') || labels.includes('runner');
+            core.info(`enforcer decide: isEvidence=${isEvidence} isCIOnly=${isCIOnly} isCILabel=${isCILabel} headRef=${headRef} labels=${labels.join(',')} paths=${paths.length}`);
             core.setOutput('is_evidence', isEvidence ? 'true' : 'false');
             core.setOutput('is_cionly', isCIOnly ? 'true' : 'false');
-      - name: Skip on evidence-only or CI-only
-        if: steps.decide.outputs.is_evidence == 'true' || steps.decide.outputs.is_cionly == 'true'
-        run: echo "enforcer skipped (evidence or ci-only)"
+            core.setOutput('is_cilabel', isCILabel ? 'true' : 'false');
+      - name: Skip on evidence-only or CI-only or CI-labeled
+        if: steps.decide.outputs.is_evidence == 'true' || steps.decide.outputs.is_cionly == 'true' || steps.decide.outputs.is_cilabel == 'true'
+        run: echo "enforcer skipped (evidence or ci-only/label)"
       - name: Enforce heavy checks for code PRs
-        if: steps.decide.outputs.is_evidence != 'true' && steps.decide.outputs.is_cionly != 'true'
+        if: steps.decide.outputs.is_evidence != 'true' && steps.decide.outputs.is_cionly != 'true' && steps.decide.outputs.is_cilabel != 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Avoid false blocks while iterating CI/runner changes: if a PR carries a `ci` or `runner` label, the enforcer skips heavy-checks requirement. (Evidence-only & `.github/**`-only are already skipped).

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

