### PR TITLE
Runner(exec): t3_hello_canary_20251114T020621Z evidence

### DIFF
--- a/codex/inbox/t3_hello_canary_20251114T020621Z.json
+++ b/codex/inbox/t3_hello_canary_20251114T020621Z.json
@@ -1,0 +1,8 @@
+{
+  "kind": "ask",
+  "source": "manual-t3",
+  "note": "T3 hello KService exec canary",
+  "actions": [
+    {"cmd": "kubectl -n default get ksvc hello"}
+  ]
+}

--- a/reports/codex_runs/t3_hello_canary_20251114T020621Z/run.log
+++ b/reports/codex_runs/t3_hello_canary_20251114T020621Z/run.log
@@ -1,0 +1,12 @@
+[INFO] Processing codex/inbox/t3_hello_canary_20251114T020621Z.json (mode=exec)
+[json] {
+[json]   "kind": "ask",
+[json]   "source": "manual-t3",
+[json]   "note": "T3 hello KService exec canary",
+[json]   "actions": [
+[json]     {
+[json]       "cmd": "kubectl -n default get ksvc hello"
+[json]     }
+[json]   ]
+[json] }
+[SKIP] not in allowlist: kubectl -n default get ksvc hello


### PR DESCRIPTION
See reports/codex_runs/t3_hello_canary_20251114T020621Z/run.log

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
- reports/codex_runs/t3_hello_canary_20251114T020621Z/run.log

