### PR TITLE
CI: generalize S5 apply manifest path for dev overlay

### DIFF
--- a/.github/workflows/ask-entry.yml
+++ b/.github/workflows/ask-entry.yml
@@ -187,21 +187,40 @@ jobs:
         run: |
           set -euo pipefail
           TS=$(date -u +%Y%m%dT%H%M%SZ)
-          if printf '%s' "$COMMENT_BODY" | grep -q 'S5 apply: dev hello-ksvc'; then
+          DEFAULT_MANIFEST="infra/k8s/overlays/dev/hello-ksvc.yaml"
+          HAS_S5_MARKER=0
+          MANIFEST=""
+          if printf '%s' "$COMMENT_BODY" | grep -iq 'S5 apply: dev'; then
+            HAS_S5_MARKER=1
+            S5_LINE=$(printf '%s\n' "$COMMENT_BODY" | grep -i 'S5 apply: dev' | head -n1 || true)
+            if [ -n "${S5_LINE:-}" ]; then
+              MANIFEST=$(printf '%s\n' "$S5_LINE" | awk '{print $4}')
+            fi
+          fi
+          if [ -z "$MANIFEST" ] || [ "$MANIFEST" = "hello-ksvc" ]; then
+            MANIFEST="$DEFAULT_MANIFEST"
+          fi
+
+          IS_DEV_MANIFEST=0
+          if printf '%s' "$MANIFEST" | grep -q '^infra/k8s/overlays/dev/'; then
+            IS_DEV_MANIFEST=1
+          fi
+
+          if [ "$HAS_S5_MARKER" -eq 1 ] && [ "$IS_DEV_MANIFEST" -eq 1 ]; then
             ID="apply_hello_dev_${TS}.json"
             FILE="codex/inbox/${ID}"
-            jq -n --arg pr "$PR_NUMBER" '{
+            jq -n --arg pr "$PR_NUMBER" --arg manifest "$MANIFEST" '{
               kind: "apply",
               source: "pr-direct-s5",
               approved: true,
               approver: "HirakuArai",
-              scope: "infra/k8s/overlays/dev/hello-ksvc.yaml",
+              scope: $manifest,
               pr_number: ($pr|tonumber),
-              note: "S5 dev apply: infra/k8s/overlays/dev/hello-ksvc.yaml",
+              note: ("S5 dev apply: " + $manifest),
               actions: [
                 {
                   type: "k8s-apply",
-                  path: "infra/k8s/overlays/dev/hello-ksvc.yaml",
+                  path: $manifest,
                   resource: {
                     kind: "Service",
                     name: "hello",

--- a/ops/runbooks/codex_runner.md
+++ b/ops/runbooks/codex_runner.md
@@ -63,14 +63,16 @@ exit 0
 # - `RUN_MODE=exec` + kind≠apply  
 #   - **S3 Canary** 相当。許可リスト（`kubectl get/describe/wait`）のみ実行し、Evidence を `run.log` に追記。
 # - `RUN_MODE=exec` + `kind=apply` + `approved=true` + `scope` が `infra/k8s/overlays/dev/**`  
-#   - **S5 apply** 専用。`kubectl diff -f <manifest>` → `kubectl apply -f <manifest>` → `kubectl get ... -o yaml` を順番に実行し、`apply.log` と `after.yaml` に記録。
+#   - **S5 apply** 専用。`kubectl diff -f <manifest>` → `kubectl apply -f <manifest>` → `kubectl get ... -o yaml` を順番に実行し、`apply.log` と `after.yaml` に記録。  
+#   - `/ask` コメント例: `S5 apply: dev infra/k8s/overlays/dev/<manifest>.yaml`（任意の dev overlay manifest）。  
+#     - `S5 apply: dev hello-ksvc` は `infra/k8s/overlays/dev/hello-ksvc.yaml` を指すショートカット。
 #
 # ### 誰がいつ回すか（Phase 2 暫定運用）
 # - **DRY**  
 #   - Runner inbox に新しい /ask JSON が溜まったら、VM Codex が 1 日 1 回程度 or 作業のまとまりで `RUN_MODE=dry bash scripts/codex_inbox_runner.sh` を実行。  
 #   - /ask コメントの結果を `_done/` へ送ることで Evidence パイプが閉じる。
 # - **EXEC (Canary/S5)**  
-#   - `RUN_MODE=exec` は「PR / /ask に EXEC して良い明示の GO サイン（例: `T3 Canary`, `S5 apply: dev hello-ksvc`）」があるときだけ。  
+#   - `RUN_MODE=exec` は「PR / /ask に EXEC して良い明示の GO サイン（例: `T3 Canary`, `S5 apply: dev ...`)」があるときだけ。  
 #   - 実行者は Codex (VM) で、対象 PR のレビュー/承認状況を確認したうえで走らせる。
 #
 # ### ログ／Evidence の見方


### PR DESCRIPTION
## Summary
- parse `/ask` comments for `S5 apply: dev <manifest>` and embed the requested dev overlay manifest path into the generated apply JSON (scope + actions[0].path)
- default to `infra/k8s/overlays/dev/hello-ksvc.yaml` for the legacy `S5 apply: dev hello-ksvc` marker while rejecting paths outside `infra/k8s/overlays/dev/`
- document the new comment format briefly in the codex runner runbook

## Testing
- `yamllint .github/workflows/ask-entry.yml`
- local shell simulation of the "Generate ask/apply" step:
  - `/ask` + `S5 apply: dev infra/k8s/overlays/dev/custom.yaml` → JSON with `scope`/`path=infra/k8s/overlays/dev/custom.yaml`
  - `/ask` + `S5 apply: dev hello-ksvc` → JSON with `scope`/`path=infra/k8s/overlays/dev/hello-ksvc.yaml`
  - `/ask` + `S5 apply: dev ../../../etc/passwd` → falls back to the regular ask JSON (safety guard)

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

