### PR TITLE
chore(kind): add kind cluster + bootstrap skeleton for hello

### DIFF
--- a/infra/kind-dev/kind-cluster.yaml
+++ b/infra/kind-dev/kind-cluster.yaml
@@ -1,6 +1,18 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-name: kind
+name: vpm-mini-kind
 nodes:
   - role: control-plane
-  - role: worker
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 31080
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 31443
+        hostPort: 443
+        protocol: TCP


### PR DESCRIPTION
## Summary
- add `infra/kind-dev/kind-cluster.yaml` describing the single-node `vpm-mini-kind` cluster (ingress-ready label + host port mappings for 80/443)
- add `scripts/p2_bootstrap_kind_knative.sh` skeleton that creates the kind cluster, wires kubeconfig, leaves TODO placeholders for Knative/kourier install, and applies + waits for `infra/k8s/overlays/dev/hello-ksvc.yaml`

## TODOs
- fill in the Knative Serving v1.18 CRD/core install commands
- add the actual kourier install steps and ingress/domain config
- decide whether to parameterize namespace/name detection from the manifest instead of using default placeholders

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

