### PR TITLE
chore(s5): add S5 inbox JSON for dev hello-ksvc apply

### DIFF
--- a/codex/inbox/apply_hello_dev_20251115T183901Z.json
+++ b/codex/inbox/apply_hello_dev_20251115T183901Z.json
@@ -1,0 +1,20 @@
+{
+  "kind": "apply",
+  "source": "pr-direct-s5",
+  "approved": true,
+  "approver": "HirakuArai",
+  "scope": "infra/k8s/overlays/dev/hello-ksvc.yaml",
+  "pr_number": 716,
+  "note": "S5 dev apply: infra/k8s/overlays/dev/hello-ksvc.yaml (hello smoke 1)",
+  "actions": [
+    {
+      "type": "k8s-apply",
+      "path": "infra/k8s/overlays/dev/hello-ksvc.yaml",
+      "resource": {
+        "kind": "Service",
+        "name": "hello",
+        "namespace": "default"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- adds a single S5 apply inbox JSON (`codex/inbox/apply_hello_dev_<ts>.json`) for dev hello-ksvc on kind vpm-mini
- runner(exec) can use it to drive the “successful” S5 apply path and capture SSOT evidence under `reports/codex_runs/apply_hello_dev_*`

## Testing
- `git diff --cached codex/inbox`

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

