### PR TITLE
evidence(hello): record S5 apply success for dev hello-ksvc

### DIFF
--- a/reports/codex_runs/apply_hello_dev_20251115T183901Z/after.yaml
+++ b/reports/codex_runs/apply_hello_dev_20251115T183901Z/after.yaml
@@ -1,0 +1,57 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"serving.knative.dev/v1","kind":"Service","metadata":{"annotations":{},"name":"hello","namespace":"default"},"spec":{"template":{"spec":{"containers":[{"env":[{"name":"TARGET","value":"World"}],"image":"gcr.io/knative-samples/helloworld-go"}]}}}}
+    serving.knative.dev/creator: kubernetes-admin
+    serving.knative.dev/lastModifier: kubernetes-admin
+  creationTimestamp: "2025-11-09T20:34:03Z"
+  generation: 2
+  name: hello
+  namespace: default
+  resourceVersion: "466195"
+  uid: d7bc81eb-d4bc-4a4b-82fe-17d55688633f
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+    spec:
+      containerConcurrency: 0
+      containers:
+      - env:
+        - name: TARGET
+          value: World
+        image: gcr.io/knative-samples/helloworld-go
+        name: user-container
+        readinessProbe:
+          successThreshold: 1
+          tcpSocket:
+            port: 0
+        resources: {}
+      enableServiceLinks: false
+      timeoutSeconds: 300
+  traffic:
+  - latestRevision: true
+    percent: 100
+status:
+  address:
+    url: http://hello.default.svc.cluster.local
+  conditions:
+  - lastTransitionTime: "2025-11-11T17:52:07Z"
+    status: "True"
+    type: ConfigurationsReady
+  - lastTransitionTime: "2025-11-11T17:52:11Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2025-11-11T17:52:11Z"
+    status: "True"
+    type: RoutesReady
+  latestCreatedRevisionName: hello-00002
+  latestReadyRevisionName: hello-00002
+  observedGeneration: 2
+  traffic:
+  - latestRevision: true
+    percent: 100
+    revisionName: hello-00002
+  url: http://hello.default.127.0.0.1.nip.io

--- a/reports/codex_runs/apply_hello_dev_20251115T183901Z/apply.log
+++ b/reports/codex_runs/apply_hello_dev_20251115T183901Z/apply.log
@@ -1,0 +1,67 @@
+[APPLY] manifest=infra/k8s/overlays/dev/hello-ksvc.yaml
+[APPLY] kubectl diff -f infra/k8s/overlays/dev/hello-ksvc.yaml
+Warning: Kubernetes default value is insecure, Knative may default this to secure in a future release: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation, spec.template.spec.containers[0].securityContext.capabilities, spec.template.spec.containers[0].securityContext.runAsNonRoot, spec.template.spec.containers[0].securityContext.seccompProfile
+[INFO] diff exited 0
+[APPLY] kubectl apply -f infra/k8s/overlays/dev/hello-ksvc.yaml
+Warning: Kubernetes default value is insecure, Knative may default this to secure in a future release: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation, spec.template.spec.containers[0].securityContext.capabilities, spec.template.spec.containers[0].securityContext.runAsNonRoot, spec.template.spec.containers[0].securityContext.seccompProfile
+service.serving.knative.dev/hello configured
+[INFO] apply exited 0
+[APPLY] kubectl get ksvc hello -n default -o yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"serving.knative.dev/v1","kind":"Service","metadata":{"annotations":{},"name":"hello","namespace":"default"},"spec":{"template":{"spec":{"containers":[{"env":[{"name":"TARGET","value":"World"}],"image":"gcr.io/knative-samples/helloworld-go"}]}}}}
+    serving.knative.dev/creator: kubernetes-admin
+    serving.knative.dev/lastModifier: kubernetes-admin
+  creationTimestamp: "2025-11-09T20:34:03Z"
+  generation: 2
+  name: hello
+  namespace: default
+  resourceVersion: "466195"
+  uid: d7bc81eb-d4bc-4a4b-82fe-17d55688633f
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+    spec:
+      containerConcurrency: 0
+      containers:
+      - env:
+        - name: TARGET
+          value: World
+        image: gcr.io/knative-samples/helloworld-go
+        name: user-container
+        readinessProbe:
+          successThreshold: 1
+          tcpSocket:
+            port: 0
+        resources: {}
+      enableServiceLinks: false
+      timeoutSeconds: 300
+  traffic:
+  - latestRevision: true
+    percent: 100
+status:
+  address:
+    url: http://hello.default.svc.cluster.local
+  conditions:
+  - lastTransitionTime: "2025-11-11T17:52:07Z"
+    status: "True"
+    type: ConfigurationsReady
+  - lastTransitionTime: "2025-11-11T17:52:11Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2025-11-11T17:52:11Z"
+    status: "True"
+    type: RoutesReady
+  latestCreatedRevisionName: hello-00002
+  latestReadyRevisionName: hello-00002
+  observedGeneration: 2
+  traffic:
+  - latestRevision: true
+    percent: 100
+    revisionName: hello-00002
+  url: http://hello.default.127.0.0.1.nip.io
+[INFO] captured state via ksvc

--- a/reports/codex_runs/apply_hello_dev_20251115T183901Z/run.log
+++ b/reports/codex_runs/apply_hello_dev_20251115T183901Z/run.log
@@ -1,0 +1,23 @@
+[INFO] Processing codex/inbox/apply_hello_dev_20251115T183901Z.json (mode=exec)
+[json] {
+[json]   "kind": "apply",
+[json]   "source": "pr-direct-s5",
+[json]   "approved": true,
+[json]   "approver": "HirakuArai",
+[json]   "scope": "infra/k8s/overlays/dev/hello-ksvc.yaml",
+[json]   "pr_number": 716,
+[json]   "note": "S5 dev apply: infra/k8s/overlays/dev/hello-ksvc.yaml (hello smoke 1)",
+[json]   "actions": [
+[json]     {
+[json]       "type": "k8s-apply",
+[json]       "path": "infra/k8s/overlays/dev/hello-ksvc.yaml",
+[json]       "resource": {
+[json]         "kind": "Service",
+[json]         "name": "hello",
+[json]         "namespace": "default"
+[json]       }
+[json]     }
+[json]   ]
+[json] }
+[INFO] Triggering S5 apply manifest=infra/k8s/overlays/dev/hello-ksvc.yaml
+[INFO] S5 apply artifacts: reports/codex_runs/apply_hello_dev_20251115T183901Z/apply.log, reports/codex_runs/apply_hello_dev_20251115T183901Z/after.yaml


### PR DESCRIPTION
## 目的

- devbox-codex 上の kind vpm-mini クラスタで、Knative Service `hello` に対する S5 apply が成功した run を SSOT evidence として残す。

## 変更点

- `codex/inbox/apply_hello_dev_20251115T183901Z.json` を Runner(exec) で実行した結果を記録：
  - `reports/codex_runs/apply_hello_dev_20251115T183901Z/apply.log`
  - `reports/codex_runs/apply_hello_dev_20251115T183901Z/after.yaml`
  - `reports/codex_runs/apply_hello_dev_20251115T183901Z/run.log`
- `kubectl diff/apply/get ksvc hello` がすべて exit 0 で完了し、
  `kubectl -n default get ksvc hello` でも READY=True を維持していることを確認。

## メモ

- この PR は Phase 2 / Goal-M2（S5 apply + hello 一巡）の「成功ルート」Evidence として扱う。
- 以前の失敗 run (#700) は non-SSOT として Close 済み。


## DoD チェックリスト（編集不可・完全一致）
- [x] Auto-merge (squash) 有効化
- [x] CI 必須チェック Green（test-and-artifacts, healthcheck）
- [x] merged == true を API で確認
- [x] PR に最終コメント（✅ merged / commit hash / CI run URL / evidence）
- [x] 必要な証跡（例: reports/*）を更新

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
- reports/codex_runs/apply_hello_dev_20251115T183901Z/after.yaml
- reports/codex_runs/apply_hello_dev_20251115T183901Z/apply.log
- reports/codex_runs/apply_hello_dev_20251115T183901Z/run.log

