### PR TITLE
chore(memory): update Goal-M2 runner_pipe and last successful S5 apply

### DIFF
--- a/data/vpm_memory_min.json
+++ b/data/vpm_memory_min.json
@@ -32,8 +32,15 @@
       "s5_apply": {
         "producer": "partial",
         "runner": "implemented",
-        "evidence_loop": "incomplete"
+        "evidence_loop": "done"
       }
+    },
+    "last_successful_s5_apply": {
+      "id": "hello_s5_apply_success_20251115",
+      "manifest": "infra/k8s/overlays/dev/hello-ksvc.yaml",
+      "reports_dir": "reports/codex_runs/apply_hello_dev_20251115T183901Z (SSOT evidence dir)",
+      "note": "Hello S5 apply success (kind vpm-mini, READY=True)",
+      "updated_at": "2025-11-15T00:00:00Z"
     },
     "open_issues": [
       "S5 apply JSON を main の codex/inbox に自動で載せる経路設計",


### PR DESCRIPTION
Update data/vpm_memory_min.json to reflect Phase 2 / Goal-M2 progress.

- Mark goal_m2.runner_pipe.s5_apply.evidence_loop as "done" (Hello S5 apply success is now recorded).
- Add last_successful_s5_apply with id=hello_s5_apply_success_20251115, manifest path, reports_dir, note, and updated_at.

This aligns the minimal VPM memory snapshot with the new SSOT evidence at reports/codex_runs/apply_hello_dev_20251115T183901Z and the updated STATE/current_state.md.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

