### PR TITLE
CI: ask-entry run Build prompt with bash

### DIFF
--- a/.github/workflows/ask-entry.yml
+++ b/.github/workflows/ask-entry.yml
@@ -62,6 +62,7 @@ jobs:
           echo "ASK_MODE=$ASK_MODE" >> "$GITHUB_ENV"
 
       - name: Build prompt
+        shell: bash
         run: |
           set -euo pipefail
           mkdir -p out reports/ask


### PR DESCRIPTION
## Summary
- set the ask-entry Build prompt step to run with shell: bash while keeping its current script content
- no other workflow steps changed; Detect mode remains sh

## Testing
- python - <<'PY'\nimport yaml\nwith open('.github/workflows/ask-entry.yml') as f:\n    yaml.safe_load(f)\nprint('YAML ok')\nPY

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

