### PR TITLE
CI: ask-entry bash-safe Build prompt

### DIFF
--- a/.github/workflows/ask-entry.yml
+++ b/.github/workflows/ask-entry.yml
@@ -63,10 +63,11 @@ jobs:
 
       - name: Build prompt
         shell: bash
+        env:
+          ISSUE_BODY: ${{ github.event_name == 'issue_comment' && github.event.comment.body || github.event.issue.body }}
         run: |
           set -euo pipefail
           mkdir -p out reports/ask
-          ISSUE_BODY="${{ github.event_name == 'issue_comment' && github.event.comment.body || github.event.issue.body }}"
           printf '%s\n' "$(cat tools/prompts/llm_relay_system.md)" > out/sys.txt
           printf 'context_header: repo=vpm-mini / branch=main / phase=Phase 2\n' > out/ctx.txt
           printf 'QUESTION\n%s\n' "$(echo "$ISSUE_BODY")" >> out/ctx.txt


### PR DESCRIPTION
## Summary
- run Build prompt under bash and source comment body via env var to avoid shell parsing issues
- Detect mode remains sh; no other workflow logic changed
- goal: avoid syntax errors in Build prompt when comment body includes bash-sensitive characters

## Testing
- bash -n (Build prompt snippet)
- python - <<'PY'\nimport yaml\nwith open('.github/workflows/ask-entry.yml') as f:\n    yaml.safe_load(f)\nprint('YAML ok')\nPY

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

