### PR TITLE
Docs: align Hello S5 north-star evidence (M2-1)

### DIFF
--- a/STATE/current_state.md
+++ b/STATE/current_state.md
@@ -30,6 +30,7 @@ Note: STATE に環境の最新状況を十分反映できていなかったた�
 - `codex/inbox/apply_hello_dev_20251115T183901Z.json` を Runner(exec) で処理し、`reports/codex_runs/apply_hello_dev_20251115T183901Z/{run.log, apply.log, after.yaml}` を生成。
 - `apply.log` 上では `kubectl diff/apply/get` がすべて `exit 0` で終了し、`kubectl -n default get ksvc hello` でも READY=True を確認。
 - この run を「Hello S5 成功ルートの SSOT Evidence」として扱い、Phase 2 Goal-M2 の技術的達成を記録した。
+- Evidence (Hello S5): run_id=apply_hello_dev_20251115T183901Z, reports_dir=reports/codex_runs/apply_hello_dev_20251115T183901Z, manifest=infra/k8s/overlays/dev/hello-ksvc.yaml, status=success (READY=True), ts=2025-11-15T09:39:01Z
 - 2025-11-15: Hello S5 の S5 apply 成功 run (apply_hello_dev_20251115T183901Z) が STATE と vpm_memory_min.json の双方で整合していることを M-2 開始時点で再確認。
 
 ### PR と SSOT の扱いルール

--- a/data/vpm_memory_min.json
+++ b/data/vpm_memory_min.json
@@ -40,7 +40,7 @@
       "manifest": "infra/k8s/overlays/dev/hello-ksvc.yaml",
       "reports_dir": "reports/codex_runs/apply_hello_dev_20251115T183901Z (SSOT evidence dir)",
       "note": "Hello S5 apply success (kind vpm-mini, READY=True)",
-      "updated_at": "2025-11-15T00:00:00Z"
+      "updated_at": "2025-11-15T09:39:01Z"
     },
     "open_issues": [
       "S5 apply JSON を main の codex/inbox に自動で載せる経路設計",


### PR DESCRIPTION
## 概要
- Issue #730 の /ask update_north_star 提案のうち、Hello S5 Evidence の1行要約を STATE/current_state.md に追記
- memory の last_successful_s5_apply.updated_at を提案どおり "2025-11-15T09:39:01Z" に揃え、他のフィールドは現状維持（id/manifest/reports_dir/note/evidence_loop）
- Detect mode (sh) など他の処理には触れていません。目的は Build prompt 後の North Star 整合性のみ

## 変更ファイル
- STATE/current_state.md
- data/vpm_memory_min.json

## テスト
- python - <<'PY'\nimport json, yaml\njson.load(open('data/vpm_memory_min.json'))\nyaml.safe_load(open('STATE/current_state.md'))\nprint('checked')\nPY

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

