### PR TITLE
State: add Phase 3 agent execution delta

### DIFF
--- a/STATE/current_state.md
+++ b/STATE/current_state.md
@@ -56,3 +56,10 @@ Note: STATE に環境の最新状況を十分反映できていなかったた�
 - M2-1: Hello S5 向け /ask update_north_star ループを確立（CONTEXT_JSON → JSON patch → 人間の採用判断 → PR #754 → STATE / memory / egspace の4層を同期）。
 - M2-2: u_contract `persist-report` レーンを policy v1 + Codex ラベル付与 + 人間の 1クリックマージ（PR #742 / #737 / #684）で検証し、`reports/**` のみ変更 + CI Green であれば M2 半自動レーンとして運用可能なことを確認。
 - M2-3: metrics-echo 向け /ask update_north_star（Issue #764）を実行したが、現状の Evidence（手動 ready-check テキスト）では JSON patch は出ず plan / warnings のみ。North Star への反映は、監視設計と Evidence 形式の整理後に後続フェーズで再チャレンジする方針とした。
+
+## Phase 3 (draft)
+
+### δ（方向と距離）
+
+- **実行主体のエージェント化**
+  - ソース改修やインフラ操作のデフォルト実行主体を、ローカル Mac Codex から LLMリレー / VM Codex を含むエージェントレーンへ移行し、人間による直接編集は「緊急 Hotfix 時の例外」として扱う。


### PR DESCRIPTION
Add an explicit delta in Phase 3 draft about shifting default execution of source/infrastructure changes from local Mac Codex to agent lanes (LLM relay / VM Codex), with human direct edits treated as emergency hotfix exceptions.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

