### PR TITLE
Docs: record P3-2 READY evidence link for metrics-echo

### DIFF
--- a/docs/memory/metrics_echo_design.md
+++ b/docs/memory/metrics_echo_design.md
@@ -124,3 +124,13 @@ Phase 4 以降:
   - 必要なら North Star と STATE / EG-Space を更新する。
 
 このメモ自体は、Phase 3 の途中で更新・拡張されることを前提としたドラフトである。
+
+---
+
+## P3-2 READY Evidence snapshot (Phase 3)
+
+- READY snapshot PR: #778  
+  - 追加ファイル: `reports/metrics-echo/metrics_echo_ready_status_p3-2.md`  
+  - 内容: `kubectl -n <namespace> get ksvc metrics-echo -o yaml` の生出力を Markdown レポートとして保存。
+- 上記レポートは、Issue #774 (P3-2: metrics-echo minimal SLI /ask retry) における
+  「READY 側 Evidence」の第一ステップとして扱う。


### PR DESCRIPTION
Append a short section in docs/memory/metrics_echo_design.md linking P3-2 READY snapshot PR #778 and the generated report file reports/metrics-echo/metrics_echo_ready_status_p3-2.md.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

