### PR TITLE
Docs: add P3-3 persist-report MVP design

### DIFF
--- a/reports/persist-report/README.md
+++ b/reports/persist-report/README.md
@@ -1,0 +1,3 @@
+# persist-report Round 1
+
+Placeholder for persist_report_mvp outputs (JSON/Markdown) generated during Round 1.


### PR DESCRIPTION
Add P3-3 persist-report cell MVP design as a draft section in docs/memory/u_contract_policy.md, defining /ask persist_report_mvp and u_contract persist-report behaviour for Round 1.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
- reports/persist-report/README.md

