### PR TITLE
Reports: P3-3 persist-report Round 1 result for #787

### DIFF
--- a/reports/persist_report_result_pr787.json
+++ b/reports/persist_report_result_pr787.json
@@ -1,0 +1,35 @@
+{
+  "pr_number": 787,
+  "pr_title": "ask: persist u_contract (reports/ask/ask_2025-11-17T0238.json)",
+  "pr_url": "https://github.com/HirakuArai/vpm-mini/pull/787",
+  "summary": "2025-11-17T02:38 に実行された /ask の結果（u_contract 関連）の JSON ログを、reports/ask/ 配下に保存するための Evidence PR。アプリケーションコードには変更を加えず、LLM 実行結果の記録のみを行っている。",
+  "tags": [
+    "ask-run",
+    "u_contract",
+    "persist-report",
+    "logs",
+    "reports-only",
+    "p3-3"
+  ],
+  "action": {
+    "suggested": "AUTO_MERGE_OK",
+    "confidence": 0.9,
+    "reasons": [
+      "変更ファイルが reports/ask/ 以下の JSON レポートのみであり、アプリケーションコードや設定値には影響しない。",
+      "内容は過去に実行された /ask の結果を残す Evidence であり、この PR をマージすることによる実行時リスクは極めて低い。"
+    ]
+  },
+  "risk_level": "LOW",
+  "notes_for_humans": [
+    "この PR は、/ask 実行ログ（u_contract 関連）の永続化であり、本番挙動やインフラ構成には影響しないタイプの変更です。",
+    "今後の persist-report セル設計では、この種の『reports/** のみを変更する Evidence PR』を優先的に AUTO_MERGE_OK に寄せていく想定です。"
+  ],
+  "u_contract": {
+    "decision": "AUTO_MERGE_OK",
+    "reason": "変更ファイルが reports/ask/ 以下の JSON レポートのみであり、/ask persist_report_mvp が AUTO_MERGE_OK かつ risk_level=LOW と判定しているため。アプリケーションコードや本番挙動への影響はなく、Evidence の追加として安全にマージ可能と判断した。",
+    "notes": [
+      "この種の reports-only / ask-run レポートは、今後も persist-report セルの AUTO_MERGE_OK の代表的なパターンになる想定。",
+      "Round 1 では自動マージせず、decision を Evidence として残すところまでをゴールとする。"
+    ]
+  }
+}

--- a/reports/persist_report_result_pr787.md
+++ b/reports/persist_report_result_pr787.md
@@ -1,0 +1,40 @@
+# P3-3 persist-report Round 1 結果 (PR #787)
+
+- 対象PR: [#787](https://github.com/HirakuArai/vpm-mini/pull/787)
+- 対象ファイル: reports/ask/ask_2025-11-17T0238.json
+- summary:
+  - 2025-11-17T02:38 に実行された /ask の結果（u_contract 関連）の JSON ログを、reports/ask/ 配下に保存する Evidence PR。
+  - アプリケーションコードや本番挙動には影響せず、LLM 実行結果を記録することのみを目的としている。
+- tags:
+  - ask-run, u_contract, persist-report, logs, reports-only, p3-3
+
+## /ask persist_report_mvp の判断（Round 1）
+
+- action.suggested: AUTO_MERGE_OK
+- confidence: 0.90
+- risk_level: LOW
+
+### reasons
+
+1. 変更ファイルが reports/ask/ 以下の JSON レポートのみであり、アプリケーションコードや設定値には影響しない。
+2. 過去に実行された /ask の結果を残す Evidence であり、この PR をマージすることによる実行時リスクは極めて低い。
+
+### notes_for_humans
+
+- この PR は、/ask 実行ログ（u_contract 関連）の永続化であり、本番挙動やインフラ構成には影響しないタイプの変更。
+- 今後の persist-report セル設計では、この種の「reports/** のみを変更する Evidence PR」を優先的に AUTO_MERGE_OK に寄せていく想定。
+
+## u_contract persist-report の最終判定
+
+- decision: AUTO_MERGE_OK
+
+### reason
+
+- 変更ファイルが reports/ask/ 以下の JSON レポートのみであり、
+  /ask persist_report_mvp が AUTO_MERGE_OK かつ risk_level=LOW と判定しているため。
+- アプリケーションコードや本番挙動への影響はなく、Evidence の追加として安全にマージ可能と判断した。
+
+### notes
+
+- この種の reports-only / ask-run レポートは、今後も persist-report セルの AUTO_MERGE_OK の代表的なパターンになる想定。
+- Round 1 ではあえて自動マージを行わず、「判定を SSOT に残す」ことをゴールとする。


### PR DESCRIPTION
Add Round 1 persist-report result for PR #787 under reports/persist-report/, including /ask persist_report_mvp JSON and u_contract persist-report decision (AUTO_MERGE_OK).

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
- reports/persist_report_result_pr787.json
- reports/persist_report_result_pr787.md

