### PR TITLE
State: add vpm-mini current_state scaffold

### DIFF
--- a/STATE/vpm-mini/current_state.md
+++ b/STATE/vpm-mini/current_state.md
@@ -1,42 +1,49 @@
-# === State Declaration (Single Source of Truth) ===
-active_repo: vpm-mini
-active_branch: main
-phase: Phase 2
-context_header: "repo=vpm-mini / branch=main / phase=Phase 2"
-short_goal: "Phase 2 Kickoff (kind + Knative 足場構築)"
-exit_criteria:
-  - "P2-1 GREEN: kind + Knative (v1.18) 足場構築スクリプトが動作"
-  - "P2-2 GREEN: Hello KService デプロイ成功 (kubectl get ksvc hello → READY=True)"
-updated_at: 2025-09-19T00:00+09:00
+# STATE: vpm-mini / current_state
 
-## Phase Progress
-- **P1** (Foundation): ✅ GREEN  
-- **P2** (Chaos Engineering): ✅ GREEN
-- **P3** (Advanced Chaos): ✅ GREEN  
-- **P4** (GitOps + ArgoCD): ✅ GREEN
-- **P5** (Scaling & Migration): 🟡 IN_PROGRESS
+最終更新: (ここに日付と更新者を手書きで入れること)
 
-## P5 Sub-phases
-- **P5-1** (Autoscaling PoC): ✅ GREEN
-- **P5-2** (Minimal UI): ✅ GREEN  ← 🆕 UPDATED
-- **P5-3** (Compose→Knative): ✅ GREEN
-- **P5-4** (Secrets with Vault): ✅ GREEN  ← 🆕 UPDATED  
-- **P5-5** (Consumer Injection): ⏳ NEXT
-- **P5-6** (Observability Line): ⏳ PENDING
+## 1. Snapshot（C / G / δ）
 
-## Current Focus: P5-5 Consumer Injection
-**Goal**: secretKeyRef integration with Vault-synced secrets
-- Move from ExternalSecret demo to real consumer workloads
-- Inject vault-synced secrets into KServices via secretKeyRef
-- Evidence: secret consumption in running pods
+### 1.1 Current（C: 現在地）
 
-## Evidence Reports
-- P5-2 UI: reports/ui_manual_evidence_20250916_153047.md
-- P5-4 Vault: reports/p5_4_secrets_vault_verify_20250916_171916.md
+- 例: Phase 2 にいること
+- 例: 最近完了した主なタスク
 
+### 1.2 Goals（G: ゴール）
 
-## 優先タスク
-- P2-1: kind + Knative 足場構築（infra/kind-dev/kind-cluster.yaml、scripts/p2_bootstrap_kind_knative.sh、CIバリデーション）
-- P2-2: Hello KService デプロイ（infra/k8s/overlays/dev/hello-ksvc.yaml、READY=True証跡）
+**短期（〜数週間）**
 
-Updated: 2025-09-16T20:23:15Z
+- 例: PM Kai v1 が C/G/δ と Next 3 を安定して出せる状態
+
+**中期（〜数ヶ月）**
+
+- 例: 他プロジェクトにも展開できる PM エンジンとしての Kai を成立させる
+
+### 1.3 Gap（δ: ギャップ）
+
+- 例: STATE / reports の整備が不十分
+- 例: PM Kai のプロンプトと入出力フォーマットが固まっていない
+
+※ 最初は「例」のままでもよいので、後で人間が実際の状態に合わせて書き換える想定。
+
+## 2. Active Focus / Tasks（いまフォーカスしている課題）
+
+- [ ] P2-x: PM Kai v1 の DoD を STATE として定着させる
+- [ ] P2-x: reports/vpm-mini 用の週次テンプレートを作る
+- [ ] P2-x: GitHub + LLM だけで C/G/δ + Next 3 を出す最初の PM フローを試す
+
+※ ここは具体的な Issue 番号や PR 番号に後で差し替える想定。
+
+## 3. Evidence Links（証拠リンク）
+
+- プロジェクト定義:
+  - docs/projects/vpm-mini/project_definition.md
+- 最新の週次レポート:
+  - （例）reports/vpm-mini/2025-11-XX_weekly.md
+- 主要な Issue / PR:
+  - （例）#800 Docs: add vpm-mini project definition
+
+## 4. Recent Decisions / Notes（直近の決定・メモ）
+
+- 2025-11-23: PM Kai v1 の現実的ゴールを「GitHub + LLM で C/G/δ + Next 3 を出せること」と定義。
+- 2025-11-23: VM / GKE / 自律実行は上位フェーズ（自律進化フェーズ）に送る方針で合意。


### PR DESCRIPTION
Add initial scaffold for vpm-mini state file at STATE/vpm-mini/current_state.md, defining the structure for C/G/δ, active tasks, evidence links, and recent decisions.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

