### PR TITLE
Reports: add vpm-mini weekly template (2025-11-23)

### DIFF
--- a/reports/vpm-mini/2025-11-23_weekly.md
+++ b/reports/vpm-mini/2025-11-23_weekly.md
@@ -1,0 +1,46 @@
+# Weekly Report: vpm-mini / 2025-11-23
+
+## 1. 今週のサマリー（Summary）
+
+- （ここに今週の全体サマリーを 3〜5 行程度で書く）
+
+## 2. 今週やったこと（Done）
+
+- [ ] （例）project_definition.md を追加し、vpm-mini の目的・制約・成功条件を SSOT 化。
+- [ ] （例）STATE/vpm-mini/current_state.md のスキャフォールドを追加。
+
+## 3. 進捗の観点からみた C/G/δ
+
+- **Current（C）**
+  - （今週の進捗を踏まえた現在地の簡潔なまとめ）
+
+- **Goals（G）**
+  - 短期:
+    - （例）PM Kai v1 が C/G/δ と Next 3 を安定して出せる状態にする。
+  - 中期:
+    - （例）他プロジェクトにも展開できる PM エンジンとしての Kai を成立させる。
+
+- **Gap（δ）**
+  - （例）PM Kai v1 の具体的な入出力フォーマットがまだ固まっていない。
+  - （例）他プロジェクト向けの project_definition / STATE が未整備。
+
+## 4. リスク・懸念（Risks / Concerns）
+
+- （例）VM/GKE コスト最適化が未完了で、精神的ノイズになっている。
+- （例）PM Kai v1 の実装・検証に使える「実データのサイクル」がまだ短い。
+
+## 5. Next 3（来週やるべきこと候補）
+
+1. （例）STATE/vpm-mini/current_state.md の C/G/δ を、今の認識で具体的に書き込む。
+2. （例）PM Kai v1 の入出力フォーマット案（プロンプトと回答形式）を固める。
+3. （例）reports/vpm-mini/2025-11-30_weekly.md を、このテンプレに沿って埋める。
+
+## 6. Evidence Links
+
+- プロジェクト定義:
+  - docs/projects/vpm-mini/project_definition.md
+- STATE:
+  - STATE/vpm-mini/current_state.md
+- 関連 PR / Issue:
+  - #800 Docs: add vpm-mini project definition
+  - #801 State: add vpm-mini current_state scaffold


### PR DESCRIPTION
Add initial weekly report template for vpm-mini at reports/vpm-mini/2025-11-23_weekly.md to capture summary, C/G/δ, risks, and Next 3.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
- reports/vpm-mini/2025-11-23_weekly.md

