### PR TITLE
State+Reports: fill vpm-mini current_state and first weekly report

### DIFF
--- a/STATE/vpm-mini/current_state.md
+++ b/STATE/vpm-mini/current_state.md
@@ -1,49 +1,62 @@
 # STATE: vpm-mini / current_state
 
-最終更新: (ここに日付と更新者を手書きで入れること)
+最終更新: 2025-11-23 by 啓
 
 ## 1. Snapshot（C / G / δ）
 
 ### 1.1 Current（C: 現在地）
 
-- 例: Phase 2 にいること
-- 例: 最近完了した主なタスク
+- Phase 2 にいるが、当面の優先フォーカスを **「PM Kai v1（GitHub + LLM のみ）」** に絞る方針に切り替えた。
+- プロジェクトの目的・制約・成功条件を `docs/projects/vpm-mini/project_definition.md` として SSOT 化済み（PR #800）。
+- `STATE/vpm-mini/current_state.md` のスキャフォールドを追加し、C/G/δ とアクティブ課題を書く器を用意した（PR #801）。
+- 週次レポートのテンプレートを `reports/vpm-mini/2025-11-23_weekly.md` に追加し、「事実ログの器」ができた（PR #802）。
+- VM / GKE / 5セル物理分散・自律実行は「上位フェーズ」に送る方針で合意し、インフラ側の検討は一時的にペンディング中。
+- GCE 側では devbox-codex VM を停止（TERMINATED）し、GKE Autopilot クラスタ `vpm-mini` および不要な PVC ディスクを削除して、ほぼゼロコスト状態に縮退済み。
 
 ### 1.2 Goals（G: ゴール）
 
 **短期（〜数週間）**
 
-- 例: PM Kai v1 が C/G/δ と Next 3 を安定して出せる状態
+- PM Kai v1 が、GitHub 上の情報（project_definition / STATE / reports / Issue / PR）だけを読んで、
+  **いつでも C/G/δ と Next 3 を一貫した形で答えられる状態**にする。
+- vpm-mini 用の PM Kai v1 を「他プロジェクトに横展開可能な PM エンジン」として使えるよう、構造（project_id 前提のレイアウト）を固める。
 
 **中期（〜数ヶ月）**
 
-- 例: 他プロジェクトにも展開できる PM エンジンとしての Kai を成立させる
+- 別プロジェクト（例: 箱根E² / 会社業務プロジェクト）にも `project_definition / STATE / reports` を整備し、
+  **vpm-mini と同じ仕組みで PM を回せる「マルチプロジェクト VPM」状態**にする。
+- EG-Space や 5セルを、まずは「論理的な視点・座標」として PM Kai の内部に導入し、物理インフラに依存しない形でテストする。
 
 ### 1.3 Gap（δ: ギャップ）
 
-- 例: STATE / reports の整備が不十分
-- 例: PM Kai のプロンプトと入出力フォーマットが固まっていない
-
-※ 最初は「例」のままでもよいので、後で人間が実際の状態に合わせて書き換える想定。
+- PM Kai v1 の **入出力フォーマット（プロンプトと回答形式）がまだ固まっていない**。
+- `STATE/vpm-mini/current_state.md` や週次レポートに、**実際の C/G/δ / Next 3 が継続的に書き込まれている状態**にはまだ至っていない。
+- 他プロジェクト向けの `docs/projects/<project_id>/project_definition.md` や `STATE/<project_id>/current_state.md` が未整備。
+- VM/GKE コスト縮退は一度完了したが、今後のための「月次インベントリレポート」などの軽い見張り仕組みは未設計。
 
 ## 2. Active Focus / Tasks（いまフォーカスしている課題）
 
-- [ ] P2-x: PM Kai v1 の DoD を STATE として定着させる
-- [ ] P2-x: reports/vpm-mini 用の週次テンプレートを作る
-- [ ] P2-x: GitHub + LLM だけで C/G/δ + Next 3 を出す最初の PM フローを試す
-
-※ ここは具体的な Issue 番号や PR 番号に後で差し替える想定。
+- [ ] **T-PM-1:** PM Kai v1 の「標準質問」と「回答フォーマット（C/G/δ + Next 3 + Evidence）」を定義する。
+- [ ] **T-PM-2:** `/ask` + GitHub Actions で、少なくとも週次で `STATE/vpm-mini/current_state.md` を更新提案できるワークフロー案を作る。
+- [ ] **T-PM-3:** `reports/vpm-mini/2025-11-23_weekly.md` を実際の内容で埋めて、週次レポートの最初の1枚を完成させる。
+- [ ] **T-INF-1:** VM/GKE コスト縮退の実績を STATE に記録し、将来のための簡易インベントリレポート（例: 月1回）をどう仕組み化するか検討する。
 
 ## 3. Evidence Links（証拠リンク）
 
 - プロジェクト定義:
-  - docs/projects/vpm-mini/project_definition.md
-- 最新の週次レポート:
-  - （例）reports/vpm-mini/2025-11-XX_weekly.md
-- 主要な Issue / PR:
-  - （例）#800 Docs: add vpm-mini project definition
+  - `docs/projects/vpm-mini/project_definition.md`（PR #800）
+- STATE:
+  - `STATE/vpm-mini/current_state.md`（本ファイル, PR #801）
+- 週次レポート・テンプレ:
+  - `reports/vpm-mini/2025-11-23_weekly.md`（PR #802）
+- 関連 PR / Issue:
+  - #800 Docs: add vpm-mini project definition
+  - #801 State: add vpm-mini current_state scaffold
+  - #802 Reports: add vpm-mini weekly template (2025-11-23)
 
 ## 4. Recent Decisions / Notes（直近の決定・メモ）
 
-- 2025-11-23: PM Kai v1 の現実的ゴールを「GitHub + LLM で C/G/δ + Next 3 を出せること」と定義。
-- 2025-11-23: VM / GKE / 自律実行は上位フェーズ（自律進化フェーズ）に送る方針で合意。
+- 2025-11-23: 「VPMのコア（PMとしての頭脳）は GitHub + LLM だけで実現できる」という前提に立ち、Phase 2 の現実的ゴールを **PM Kai v1** に再定義。
+- 2025-11-23: 実行力（自律デプロイなど）は「自律進化フェーズ」として切り離し、当面は扱わない方針で合意。
+- 2025-11-23: VM / GKE / 5セル物理実装は「将来の実行環境」とし、現フェーズでは PM Kai の頭脳設計に集中することを優先。
+- 2025-11-23: devbox-codex VM を停止し、GKE Autopilot クラスタ `vpm-mini` と不要な PVC ディスクを削除して、インフラコストをほぼゼロまで縮退。

--- a/reports/vpm-mini/2025-11-23_weekly.md
+++ b/reports/vpm-mini/2025-11-23_weekly.md
@@ -2,45 +2,53 @@
 
 ## 1. 今週のサマリー（Summary）
 
-- （ここに今週の全体サマリーを 3〜5 行程度で書く）
+- vpm-mini プロジェクトに対して「PM Kai v1（GitHub + LLM で C/G/δ + Next 3 を出す頭脳）」を現実的ゴールとする方針を固めた。
+- VM/GKE や 5セル物理実装、自律実行は「上位フェーズ」に切り離し、まずは PM としての機能に集中することにした。
+- プロジェクト定義、STATE スキャフォールド、週次レポートテンプレートを追加し、Kai が読むべき SSOT の骨格が整った。
+- GCP 側では devbox-codex VM を停止し、GKE Autopilot クラスタ `vpm-mini` と不要な PVC ディスクを削除して、インフラコストをほぼゼロに縮退した。
 
 ## 2. 今週やったこと（Done）
 
-- [ ] （例）project_definition.md を追加し、vpm-mini の目的・制約・成功条件を SSOT 化。
-- [ ] （例）STATE/vpm-mini/current_state.md のスキャフォールドを追加。
+- [x] `docs/projects/vpm-mini/project_definition.md` を追加し、vpm-mini の目的・制約・成功条件を SSOT 化（PR #800）。
+- [x] `STATE/vpm-mini/current_state.md` のスキャフォールドを追加し、C/G/δ とアクティブ課題の器を用意（PR #801）。
+- [x] `reports/vpm-mini/2025-11-23_weekly.md` のテンプレートを追加し、週次レポートのフォーマットを固定（PR #802）。
+- [x] devbox-codex VM を停止し、GKE Autopilot クラスタ `vpm-mini` および不要な PVC ディスクを削除して、インフラコストをほぼゼロに縮退。
 
 ## 3. 進捗の観点からみた C/G/δ
 
 - **Current（C）**
-  - （今週の進捗を踏まえた現在地の簡潔なまとめ）
+  - PM Kai v1 に必要な「目的」「現在地の器」「週次レポートの器」が GitHub 上に整備され、頭脳の土台が見えてきた。
+  - インフラコストの問題は一旦きれいに片付き、PM Kai の設計に集中しやすい状態になった。
+  - まだ運用は始まっておらず、Kai が実際に C/G/δ + Next 3 を出すループは整っていない。
 
 - **Goals（G）**
   - 短期:
-    - （例）PM Kai v1 が C/G/δ と Next 3 を安定して出せる状態にする。
+    - PM Kai v1 が、vpm-mini について C/G/δ と Next 3 を一貫した形で答えられる状態にする。
   - 中期:
-    - （例）他プロジェクトにも展開できる PM エンジンとしての Kai を成立させる。
+    - 同じ仕組みを他プロジェクトにも展開し、「マルチプロジェクト VPM」として使える PM エンジンを確立する。
 
 - **Gap（δ）**
-  - （例）PM Kai v1 の具体的な入出力フォーマットがまだ固まっていない。
-  - （例）他プロジェクト向けの project_definition / STATE が未整備。
+  - PM Kai v1 の具体的な入出力フォーマット（質問テンプレートと回答の型）が未定義。
+  - `/ask` + GitHub Actions による STATE / reports 更新ループが存在しない。
+  - 他プロジェクト用の project_definition / STATE / reports がまだゼロ。
 
 ## 4. リスク・懸念（Risks / Concerns）
 
-- （例）VM/GKE コスト最適化が未完了で、精神的ノイズになっている。
-- （例）PM Kai v1 の実装・検証に使える「実データのサイクル」がまだ短い。
+- PM Kai v1 の入出力設計を曖昧なまま進めると、「C/G/δ と Next 3」の一貫性が崩れ、VPM の信頼性が損なわれるリスク。
 
 ## 5. Next 3（来週やるべきこと候補）
 
-1. （例）STATE/vpm-mini/current_state.md の C/G/δ を、今の認識で具体的に書き込む。
-2. （例）PM Kai v1 の入出力フォーマット案（プロンプトと回答形式）を固める。
-3. （例）reports/vpm-mini/2025-11-30_weekly.md を、このテンプレに沿って埋める。
+1. `STATE/vpm-mini/current_state.md` の C/G/δ とアクティブ課題を、必要に応じて微調整しつつ「現時点の認識」として確定させる。
+2. PM Kai v1 の標準質問と回答フォーマット（C/G/δ + Next 3 + Evidence Links）を文書として決める。
+3. `/ask` + GitHub Actions で、週次 or 手動トリガで `STATE/vpm-mini/current_state.md` を更新提案する簡単なワークフロー案を作る。
 
 ## 6. Evidence Links
 
 - プロジェクト定義:
-  - docs/projects/vpm-mini/project_definition.md
+  - `docs/projects/vpm-mini/project_definition.md`
 - STATE:
-  - STATE/vpm-mini/current_state.md
+  - `STATE/vpm-mini/current_state.md`
 - 関連 PR / Issue:
   - #800 Docs: add vpm-mini project definition
   - #801 State: add vpm-mini current_state scaffold
+  - #802 Reports: add vpm-mini weekly template (2025-11-23)


### PR DESCRIPTION
Fill STATE/vpm-mini/current_state.md with the current C/G/δ snapshot and active tasks, and populate reports/vpm-mini/2025-11-23_weekly.md as the first weekly report for vpm-mini.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
- reports/vpm-mini/2025-11-23_weekly.md

