### PR TITLE
CI: enable manual dispatch for pm_snapshot workflow

### DIFF
--- a/.github/workflows/pm_snapshot.yml
+++ b/.github/workflows/pm_snapshot.yml
@@ -4,9 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       project_id:
-        description: Target project_id (default: vpm-mini)
+        description: "Target project_id (e.g. vpm-mini)"
         required: false
-        default: vpm-mini
+        default: "vpm-mini"
+  push:
+    paths:
+      - ".github/workflows/pm_snapshot.yml"
+  pull_request:
+    paths:
+      - ".github/workflows/pm_snapshot.yml"
 
 jobs:
   snapshot:


### PR DESCRIPTION
Add workflow_dispatch trigger with project_id input so PM snapshot workflow can be run manually from the Actions UI.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

