### PR TITLE
CI: upload PM snapshot as artifact

### DIFF
--- a/.github/workflows/pm_snapshot.yml
+++ b/.github/workflows/pm_snapshot.yml
@@ -116,3 +116,9 @@ jobs:
 
           echo "Saved snapshot to $SNAP_OUT"
           head -n 20 "$SNAP_OUT" || true
+
+      - name: Upload PM snapshot artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pm_snapshot-${{ github.event.inputs.project_id || 'vpm-mini' }}
+          path: reports/pm_snapshots/*.md


### PR DESCRIPTION
Update pm_snapshot workflow to upload generated PM snapshot markdown files as a GitHub Actions artifact (no commit/push to the repo).

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

