### PR TITLE
Docs: add doc_update pipeline and review spec v1

### DIFF
--- a/docs/pm/doc_update_pipeline_v1.md
+++ b/docs/pm/doc_update_pipeline_v1.md
@@ -1,0 +1,181 @@
+# Doc Update Pipeline v1
+repo=vpm-mini / branch=main  
+Phase 2 (PM Kai v1 + Layer B / Proposer & Reviewer Kai → Codex 連携フェーズ)
+
+このドキュメントは、PM Kai v1 による **ドキュメント更新パイプライン**を定義する。
+
+- Proposer Kai（提案者）
+- Reviewer Kai（評価者）
+- Human（啓＋ChatGPT）
+- Codex（実行器）
+
+の 4 つの役割が、JSON を中心にどのように連携するかを示す。
+
+---
+
+## 1. 目的とスコープ
+
+### 1.1 目的
+
+- Kai がプロジェクトの進捗を読み取り、
+  「どのドキュメントを、なぜ、どう更新すべきか」を **JSON 形式**で提案する。
+- 別レイヤーの Kai が、その提案を **JSON 形式**で評価する。
+- Human（啓＋ChatGPT）は、JSON の中身は書き換えず、
+  **採用するかどうか（Accept/Reject）を判断する**ことに集中する。
+- 採用された提案 JSON を、Codex が **そのまま読み込んで更新＋PR** まで実行する。
+
+### 1.2 スコープ
+
+このパイプラインが扱う対象は、以下のファイル群：
+
+- docs/projects/<project_id>/project_definition.md
+- STATE/<project_id>/current_state.md
+- reports/<project_id>/YYYY-MM-DD_weekly.md
+- その他、プロジェクトに紐づく Markdown / JSON ドキュメント
+
+---
+
+## 2. 役者と成果物
+
+### 2.1 Proposer Kai（提案者）
+
+ワークフロー:
+
+- .github/workflows/pm_snapshot.yml
+  - 出力: pm_snapshot_v1 JSON＋Markdownビュー
+- .github/workflows/doc_update_proposal.yml
+  - 出力: doc_update_proposal_v1 JSON
+
+成果物:
+
+- pm_snapshot_v1  
+  - C / G(short, mid) / δ / Next 3 / Evidence
+- doc_update_proposal_v1
+  - updates[]（どのファイルを、なぜ、どう変えるか）
+  - no_change[]
+  - notes[]
+
+### 2.2 Reviewer Kai（評価者）※新設
+
+Proposer Kai の doc_update_proposal_v1 を評価し、
+「どの更新提案をどう扱うべきか」を JSON で返す。
+
+成果物:
+
+- doc_update_review_v1 JSON（詳細は doc_update_review_v1_spec.md を参照）
+  - proposal 全体の評価（overall_assessment）
+  - 各 updates に対する judgement（accept / reject など）
+  - 補足メモ（notes）
+
+Reviewer Kai 自身はファイルを直接編集しない。
+
+### 2.3 Human（啓＋ChatGPT）
+
+- Proposer Kai → Reviewer Kai の JSON を読み、
+  - 提案内容
+  - リスクレベル
+  - judgement 内容
+- を踏まえて **採用/不採用を決める**。
+
+Human が原則としてやらないこと:
+
+- doc_update_proposal_v1 / doc_update_review_v1 の中身を直接書き換えること  
+  （Kai の出力は Kai の「公式アウトプット」として尊重する）
+
+必要に応じて:
+
+- コメントやメモを別ファイル／Issue コメントとして残す。
+
+### 2.4 Codex（実行器）
+
+- Human が「採用」と判断した doc_update_proposal_v1 を受け取り、
+- JSON を解析して updates[] の内容を対象ファイルに適用する。
+- コミット＋PR作成までを担当する。
+
+Codex は内容を再解釈せず、
+**target.path / change_type / suggestion_markdown に従って機械的に適用**する。
+
+---
+
+## 3. パイプラインのフロー
+
+### 3.1 トリガー（進捗の発生）
+
+- 啓が「最近の進捗」を progress_summary としてまとめる。
+- 対象の project_id を決める（例: vpm-mini, hakone-e2）。
+
+### 3.2 Proposer Kai フェーズ
+
+1. pm_snapshot.yml を project_id 指定で実行
+   - 最新の C / G / δ / Next 3 / Evidence を取得
+2. doc_update_proposal.yml を実行
+   - 入力:
+     - project_id
+     - progress_summary
+   - 出力:
+     - reports/doc_update_proposals/YYYY-MM-DD_<project_id>.json
+       （doc_update_proposal_v1）
+
+### 3.3 Reviewer Kai フェーズ
+
+1. Reviewer Kai が doc_update_proposal_v1（＋必要に応じて SSOT）を読む
+2. doc_update_review_v1 を出力
+   - proposal_ref で proposal JSON を参照
+   - overall_assessment に全体評価
+   - update_judgements[] に各 updates への judgement
+3. doc_update_review_v1 は JSON のみを SSOT とし、
+   必要なビューは後から生成する。
+
+### 3.4 Human フェーズ（採用/不採用の判断）
+
+Human（啓＋ChatGPT）は：
+
+1. doc_update_proposal_v1 と doc_update_review_v1 をセットで読む
+2. 次を判断する:
+   - 今回の proposal を **丸ごと採用してよいか？**
+   - or 今回は見送るべきか？
+3. 判断結果は、以下のいずれかで記録する（運用レベルで決定）:
+   - Issue コメント
+   - reports/... 配下のメモファイル
+   - あるいは将来の apply_plan JSON（部分適用フェーズ用）
+
+Phase 2 では、まず **proposal 全体の Accept/Reject** から始める。
+
+### 3.5 Codex フェーズ（適用＋PR）
+
+1. Human が **ACCEPT** と判断したら、
+2. Codex に対して、統一テンプレートのブリーフを渡す:
+   - プロジェクト: HirakuArai/vpm-mini
+   - PROPOSAL_PATH=reports/doc_update_proposals/YYYY-MM-DD_<project_id>.json
+   - 「この PROPOSAL を読み、updates[] を適用して PR を作成してほしい」
+
+Codex は:
+
+- target.path に対して、change_type / suggestion_markdown で編集
+- コミット＋ PR 作成
+  - PR タイトルや本文には、PROPOSAL_PATH と主な変更点（updates の要約）を含める。
+
+---
+
+## 4. JSON を SSOT にする方針
+
+- PM Kai の「考えた結果」は、原則すべて JSON を SSOT とする。
+  - pm_snapshot_v1 → JSON を「正」とし、Markdown はビュー。
+  - doc_update_proposal_v1 → JSON が「正」。
+  - doc_update_review_v1 → JSON のみ。
+- 人間向けの読みやすさは、
+  - JSON → Markdownビュー生成
+  - JSON → LLMによる解説テキスト
+  で吸収する。
+
+---
+
+## 5. 将来の拡張について（メモ）
+
+- 部分適用（updates 単位の Accept/Reject）を扱いたくなった場合は、
+  - apply_plan のような別 JSON を導入し、
+  - doc_update_proposal_v1 自体は不変のままにする。
+- 自動マージレベルの引き上げ（人間レビューを薄くする）は、
+  - doc_update_review_v1.overall_assessment.risk_level
+  - 過去の手修正ログ
+  を根拠に、後続フェーズで検討する。

--- a/docs/pm/doc_update_review_v1_spec.md
+++ b/docs/pm/doc_update_review_v1_spec.md
@@ -1,0 +1,170 @@
+# doc_update_review_v1 Spec
+repo=vpm-mini / branch=main  
+Phase 2 (PM Kai v1 + Layer B / Reviewer Kai)
+
+doc_update_review_v1 は、**Reviewer Kai が doc_update_proposal_v1 を評価した結果**を表す JSON 形式の SSOT である。
+
+- Proposer Kai の提案 (doc_update_proposal_v1)
+- Reviewer Kai の評価 (doc_update_review_v1)
+- Human（啓＋ChatGPT）の判断（Accept/Reject）
+
+の 3レイヤーを明確に分離するためのフォーマット。
+
+---
+
+## 1. デザイン方針
+
+- **JSON を SSOT とする**  
+  Markdownビューは必要に応じて生成するだけで、原本は常に JSON。
+- Reviewer Kai は **ファイルを直接編集しない**。  
+  あくまで「提案をどう扱うべきか」のメタ情報を出す。
+- Human は JSON を読み、
+  - 「この proposal＋review セットを採用してよいか？」を判断する。
+  - JSON 自体は原則変更しない。
+
+---
+
+## 2. スキーマ概要
+
+トップレベル構造（v1 の最小形の例）:
+
+    {
+      "schema_version": "doc_update_review_v1",
+      "project_id": "vpm-mini",
+      "proposal_ref": "reports/doc_update_proposals/2025-11-24_vpm-mini.json",
+      "generated_at": "2025-11-24T16:30:00+09:00",
+    
+      "overall_assessment": {
+        "summary": "提案内容は目的と整合しており低リスク。STATE と weekly の整合性も保たれる。",
+        "risk_level": "low"
+      },
+    
+      "update_judgements": [
+        {
+          "target_path": "STATE/vpm-mini/current_state.md",
+          "section_hint": "1.1 Current",
+          "decision": "accept",
+          "reason": "Layer B 設計書の追加と hakone-e2 試行の反映は現状を正しく表現しているため。",
+          "suggestion_override": null
+        }
+      ],
+    
+      "notes": [
+        "今回のレビューは、Layer B 設計 v1 と hakone-e2 での試行結果を前提に行った。",
+        "高リスクな変更は含まれていないと判断。"
+      ]
+    }
+
+---
+
+## 3. フィールド定義
+
+### 3.1 メタ情報
+
+- schema_version (string, required)  
+  例: "doc_update_review_v1"
+
+- project_id (string, required)  
+  例: "vpm-mini", "hakone-e2"
+
+- proposal_ref (string, required)  
+  評価対象となる doc_update_proposal_v1 のパス。  
+  例: "reports/doc_update_proposals/2025-11-24-vpm-mini.json"
+
+- generated_at (string, required)  
+  ISO 8601 形式の生成日時（タイムゾーン付き推奨）。  
+  例: "2025-11-24T16:30:00+09:00"
+
+---
+
+### 3.2 overall_assessment
+
+Reviewer Kai による、proposal 全体の評価。
+
+    "overall_assessment": {
+      "summary": "提案内容は目的と整合しており低リスク。STATE と weekly の整合性も保たれる。",
+      "risk_level": "low"
+    }
+
+- summary (string, required)  
+  人間が読むことを前提とした要約コメント。
+
+- risk_level (string, required)  
+  提案全体のリスクレベル。  
+  v1 では以下の 3 値とする：
+  - "low": ほぼ自明／誤っても影響が小さい
+  - "medium": 内容の妥当性を慎重に見る必要がある
+  - "high": 人間の詳細レビューを必須とすべき、または採用は慎重に検討
+
+---
+
+### 3.3 update_judgements[]
+
+doc_update_proposal_v1.updates[] に対する、Reviewer Kai の判断。
+
+    "update_judgements": [
+      {
+        "target_path": "STATE/vpm-mini/current_state.md",
+        "section_hint": "1.1 Current",
+        "decision": "accept",
+        "reason": "Layer B 設計書の追加と hakone-e2 試行の反映は現状を正しく表現しているため。",
+        "suggestion_override": null
+      }
+    ]
+
+各要素のフィールド：
+
+- target_path (string, required)  
+  対象ファイルのパス。  
+  doc_update_proposal_v1.updates[i].target.path に対応。
+
+- section_hint (string, optional)  
+  対象となるセクションのヒント。  
+  例: "1.1 Current", "Next 3" など。  
+  Proposer からコピーしてもよいし、Reviewer が補足してもよい。
+
+- decision (string, required)  
+  Reviewer Kai による judgement。  
+  v1 ではまず以下の 2 値から始める：
+  - "accept": 提案通りに適用してよい
+  - "reject": 提案は採用すべきでない
+
+  将来拡張として "accept_with_edits" を追加する余地を残す。
+
+- reason (string, required)  
+  その judgement に至った理由。Human が判断しやすいように書く。
+
+- suggestion_override (string or null, optional)  
+  - v1 では原則 null。  
+  - 将来的に "accept_with_edits" を導入する際、
+    Proposer の suggestion_markdown を上書きしたいときに使用する。
+
+---
+
+### 3.4 notes[]
+
+Reviewer Kai からの補足メモ。
+
+    "notes": [
+      "今回のレビューは、Layer B 設計 v1 と hakone-e2 での試行結果を前提に行った。",
+      "高リスクな変更は含まれていないと判断。"
+    ]
+
+- 予備条件や前提
+- 今後の提案へのフィードバック
+- Human が判断するときに知っておくとよい背景
+
+などを自由形式で書く。
+
+---
+
+## 4. 運用上の前提（Phase 2）
+
+- doc_update_review_v1 は Reviewer Kai の「公式アウトプット」として扱う。
+- Human（啓＋ChatGPT）は：
+  - doc_update_proposal_v1＋doc_update_review_v1 を読み、
+  - proposal 全体を **ACCEPT** するか **REJECT** するかを決める。
+- Phase 2 の間は、**proposal 全体の採用/不採用** を扱い、
+  updates 単位の部分適用は後続フェーズの課題とする。
+- JSON の中身を人間が直接編集することは避け、
+  必要な補足や異論は外側（レポート、Issue コメント等）に記録する。


### PR DESCRIPTION
Add initial design docs for PM Kai doc_update pipeline (Proposer/Reviewer/Human/Codex) and doc_update_review_v1 JSON schema spec.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

