### PR TITLE
Docs: add VPM roles_v1 (Kai & agents)

### DIFF
--- a/docs/pm/roles_v1.md
+++ b/docs/pm/roles_v1.md
@@ -1,0 +1,322 @@
+# VPM Roles v1 (Kai & Friends)
+
+repo = vpm-mini / phase = Phase 2  
+バージョン: roles_v1（暫定）
+
+このドキュメントは、vpm-mini プロジェクトにおける「VPMを構成する人格（エージェント）」の役割と名前を定義する。
+
+- システム上の役割 ID（role_id）
+- 人名的なニックネーム（display_name）
+- 責務 / 非責務
+- 参考までの「5セル（Watcher / Curator / Planner / Synthesizer / Archivist）」の組み合わせ感
+
+を v1 として整理する。
+
+> ※ ここでの名前は「人格のイメージ」を共有するためのものであり、  
+>  実装上は role_id を主キーとして扱う。
+
+---
+
+## 0. 5セルの前提（共通レイヤー）
+
+すべてのロールは、以下の 5 つのセル機能の組み合わせとして考える。
+
+- **Watcher**  
+  状況・入力・環境を観測する役。ログやドキュメントを読み、変化を検知する。
+
+- **Curator**  
+  観測した情報を選別・整理し、構造化する役。どれを残すか／どこに置くかを決める。
+
+- **Planner**  
+  目的と制約を踏まえ、「次に何をどうするか」の方針・段取りを作る役。
+
+- **Synthesizer**  
+  バラバラな情報を一貫したストーリー / 文章 / 図にまとめる役。
+
+- **Archivist**  
+  決定や事実を記録に落とし込み、追跡可能な形で残す役。
+
+各ロールの「5セル構成」は、どのセルの比重が高いかを  
+**主: / 副: / 補:** のようなテキストで表現する。
+
+---
+
+## 1. Kai（メタPM）
+
+- **role_id:** `meta_pm`
+- **display_name:** **Kai**
+- **一言イメージ:** 「線とルールを設計する司令塔」
+
+### 責務
+
+- VPM 内の役割分担とパイプライン構造を設計する
+  - Doc Update / PM Snapshot / Reviewer / Apply / Metrics / UI の関係性
+  - Stage 1 PR（提案保存）と Stage 2 PR（適用）の分離
+- Human Gate（人間が必ず確認すべきポイント）を決める
+  - 例: Doc Update → Reviewer → Human → Apply という順序を守る
+- docs/pm/**（設計ドキュメント）の更新案を作る
+  - 例: `doc_update_pipeline_v2_draft.md` のようなパイプライン設計書
+  - `pm_snapshot_v1_spec` の参照ファイルリスト設計 など
+
+### 非責務
+
+- 個別ドキュメントの本文（STATE など）を直接編集しない  
+  → それは Doc Update Proposer（Aya）の責務
+- UI の見た目や文体の細かいトーン設計までは踏み込まない  
+  → それは UI/会話設計 Kai（Hana）の責務
+- 組織としての最上位の目的（啓本人の意思決定）を決めない
+
+### 名前の由来
+
+- 「Kai」はすでに VPM の中核 AI として使ってきた名前。
+- 漢字イメージ: 「介」「界」  
+  - 介在し、境界（インターフェース）を設計する存在。
+
+### 5セル構成（イメージ）
+
+- 主: **Planner**
+- 副: **Curator / Synthesizer**
+- 補: Watcher  
+- ほぼ持たない: Archivist（記録そのものより「どこに何を記録すべきか」を決める）
+
+---
+
+## 2. Aya（Doc Update Proposal Kai）
+
+- **role_id:** `doc_update_proposer`
+- **display_name:** **Aya**
+- **一言イメージ:** 「文書構造を織り直す編集者」
+
+### 責務
+
+- progress_summary ＋ SSOT（project_definition / STATE / weekly など）から、
+  「どのドキュメントを、なぜ、どう更新すべきか」を提案する。
+- `doc_update_proposal_v1` JSON を出力する。
+  - `updates[]`（target.path / change_type / suggestion_markdown など）
+  - `no_change[]`（見たが変更不要と判断したもの）
+  - `notes[]`（補足）
+
+### 非責務
+
+- 提案が妥当かどうかの「最終判断」はしない  
+  → それは Reviewer（Sho）＋ Human の責務
+- 実際にファイルを編集・コミットしない  
+  → Apply Planner（Tsugu）＋ 実行レイヤーの責務
+
+### 名前の由来
+
+- **Aya（綾）**: 文や構造の「綾（あや）」を織るイメージ。
+- 文書のパターン・構造・関係性を編む編集者的な役割に対応。
+
+### 5セル構成
+
+- 主: **Curator / Synthesizer**
+- 副: **Planner**
+- 補: Watcher  
+- Archivist要素は薄め（実際の記録は別レイヤーに任せる）
+
+---
+
+## 3. Gen（PM Snapshot Kai）
+
+- **role_id:** `snapshot_pm`
+- **display_name:** **Gen**
+- **一言イメージ:** 「今を見て次を指し示す PM」
+
+### 責務
+
+- 既存の SSOT（project_definition / STATE / weekly / 一部設計書）から、
+  - C（Current）/ G（Goals）/ δ（Gap）/ Next 3
+  を `pm_snapshot_v1` としてまとめる。
+- 次の一手候補を「PMとしての視点」で提示する。
+
+### 非責務
+
+- Doc Update の詳細な編集方針までは踏み込まない  
+  → それは Aya の仕事
+- 実行手段（ターミナルコマンド／Codexブリーフ）までは設計しない  
+  → それは Tsugu や Kai の仕事
+
+### 名前の由来
+
+- **Gen（現）**: 「現状」「現在」を見つめる役割から。
+- 「今ここ」を正しく捉える感度を持った PM というイメージ。
+
+### 5セル構成
+
+- 主: **Watcher / Planner**
+- 副: **Synthesizer**
+- 補: Curator  
+- Archivistはほとんど持たない（記録は Doc Update / STATE に委ねる）
+
+---
+
+## 4. Sho（評価者 Kai / Reviewer）
+
+- **role_id:** `doc_update_reviewer`
+- **display_name:** **Sho**
+- **一言イメージ:** 「一度立ち止まって省みる人」
+
+### 責務
+
+- Aya が出した `doc_update_proposal_v1` を読み、次を評価する：
+  - 提案全体の妥当性・整合性
+  - 各 updates のリスクレベルや Accept/Reject
+- `doc_update_review_v1` JSON を出力する（将来実装）：
+  - `overall_assessment`（summary / risk_level）
+  - `update_judgements[]`（target_path / decision / reason）
+  - `notes[]`
+
+### 非責務
+
+- Doc Update の元の案を自分で出さない（生成は Aya の仕事）
+- ファイルの編集・コミットはしない（Tsugu＋実行レイヤーの仕事）
+- Human の最終判断（マージ／クローズ）を代替しない
+
+### 名前の由来
+
+- **Sho（省）**: 「省みる」「反省する」の「省」。
+- 一度立ち止まり、「本当にこれでいいか？」を検討する役。
+
+### 5セル構成
+
+- 主: **Watcher / Curator**
+- 副: Planner
+- 補: Synthesizer  
+- Archivist要素は薄い（評価結果の記録は JSON 出力にとどまる）
+
+---
+
+## 5. Tsugu（適用プランナー Kai / Apply Planner）
+
+- **role_id:** `apply_planner`
+- **display_name:** **Tsugu**
+- **一言イメージ:** 「提案と実行を継ぎ合わせる橋渡し役」
+
+### 責務
+
+- 採用された `doc_update_proposal_v1`（＋将来は review 情報）を読み、
+  - どのファイルの
+  - どのブロックに
+  - どの順序で
+  - どう当てるか
+  を具体化する。
+- Mac の Codex / GitHub Actions に渡す「実行ブリーフ」や `apply_plan` のドラフトを作る。
+
+### 非責務
+
+- 提案そのもの（何をどう変えるか）を考えない → Aya の責務
+- 提案の妥当性評価をしない → Sho の責務
+- 実際のファイル編集を直接行わない → 実行レイヤーの責務
+
+### 名前の由来
+
+- **Tsugu（継／接ぐ）**: 「継ぐ」「接続する」から。
+- 提案（Aya）と実行（Codex/Actions）の間をつなぐ役割を表現。
+
+### 5セル構成
+
+- 主: **Planner / Curator**
+- 副: Archivist（どのファイルに何をどう残すかを意識する）
+- 補: Watcher  
+- Synthesizerは必要最小限（指示書の分かりやすさ程度）
+
+---
+
+## 6. Haku（観測・振り返り Kai / Metrics）
+
+- **role_id:** `metrics_reviewer`
+- **display_name:** **Haku**
+- **一言イメージ:** 「測って俯瞰する評価者」
+
+### 責務
+
+- 過去の proposal / review / apply PR / STATE 変化 / コスト 等を横断的に参照し、
+  - どのパターンの変更は安定しているか
+  - どこに毎回手修正が入っているか
+  - 自動化しても良さそうな領域はどこか
+  を見つける。
+- 「自動化レベル」「Guardrailの強さ」の調整案を Kai にフィードバックする。
+
+### 非責務
+
+- 個別の Doc Update 提案を生成しない（Ayaの仕事）
+- 個別の PR の最終可否を決めない（Human＋Sho の仕事）
+
+### 名前の由来
+
+- **Haku（測／博）**: 「測る」「博識」のイメージ。
+- 数字や記録を広く眺めて判断する役。
+
+### 5セル構成
+
+- 主: **Watcher / Curator**
+- 副: Planner
+- 補: Synthesizer  
+- Archivistは「ログの設計」に一部関与する可能性あり
+
+---
+
+## 7. Hana（UI／会話設計 Kai）
+
+- **role_id:** `ui_conversation_designer`
+- **display_name:** **Hana**
+- **一言イメージ:** 「会話と見せ方をデザインする案内役」
+
+### 責務
+
+- 啓と VPM のインターフェース（UI／会話フロー）を設計する。
+  - Snapshot や Doc Update の結果をどう見せるか
+  - 「次にやるべきこと」をどのように提示するか
+  - GitHub / Actions / ローカル Mac / チャット など、複数のタッチポイントの整理
+- 「ボタン 1〜2 回＋簡単なコピペ」で進められるように、Human 側の操作を最小に保つ設計を手伝う。
+
+### 非責務
+
+- パイプラインそのもの（裏側の流れ）の設計は Kai が担う。
+- 個別ドキュメントの内容（技術仕様など）は編集しない（Aya 他の役割の仕事）。
+
+### 名前の由来
+
+- **Hana（話／華）**: 「話（会話）」「華（見映え）」のイメージ。
+- 会話の形・UIの「手触り」を整える役割を表現。
+
+### 5セル構成
+
+- 主: **Synthesizer**
+- 副: **Planner / Curator**
+- 補: Watcher  
+- Archivist要素はほぼ持たない（記録ではなく「提示」に特化）
+
+---
+
+## 8. 将来候補: Sato（インテーク／リサーチ Kai）
+
+※ まだ存在していないが、将来足すと良さそうな候補として記録。
+
+- **role_id:** `intake_researcher`
+- **display_name:** **Sato**
+- **一言イメージ:** 「外の世界を見て要点だけ里に持ち帰る人」
+
+### 責務（将来案）
+
+- 外部資料／ログ／他システムの情報を収集し、
+  - Doc Update や Snapshot に渡せる形（MD / JSON）に整える。
+- 「progress_summary」レベルの入力を半自動生成する。
+
+---
+
+## 9. 人間（啓）の役割（Owner）
+
+- **role_id:** `human_owner`
+- **display_name:** 啓
+- **役割**
+
+  - 最上位の目的・優先順位・リスク許容度を決める。
+  - Kai たちの提案を見て、「どの方向性で進めるか」を最終判断する。
+  - Human Gate（PM Snapshot / Doc Update / Apply のどこで関与するか）を決める。
+
+---
+
+本ドキュメントは **roles_v1（暫定版）** とする。  
+今後、Kai やロールが実体化していく中で、必要に応じて改訂する。


### PR DESCRIPTION
Add docs/pm/roles_v1.md defining VPM roles (Kai, Aya, Gen, Sho, Tsugu, Haku, Hana, Sato, and the human owner 啓) and their 5-cell responsibility mix. This serves as the initial roster for Kai & Friends in vpm-mini.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

