### PR TITLE
CI: add Doc Update Review (Sho) workflow v1

### DIFF
--- a/.github/workflows/doc_update_review.yml
+++ b/.github/workflows/doc_update_review.yml
@@ -1,0 +1,84 @@
+name: Doc Update Review (Sho)
+
+on:
+  workflow_dispatch:
+    inputs:
+      project_id:
+        description: "Project ID (e.g. vpm-mini)"
+        required: true
+        default: "vpm-mini"
+      proposal_path:
+        description: "Path to doc_update_proposal_v1 JSON in the repo"
+        required: true
+        default: "reports/doc_update_proposals/2025-11-24-vpm-mini.json"
+
+jobs:
+  review_doc_update_proposal:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Show context
+        run: |
+          echo "project_id=${{ github.event.inputs.project_id }}"
+          echo "proposal_path=${{ github.event.inputs.proposal_path }}"
+          ls -R
+
+      - name: Load proposal JSON
+        id: load_proposal
+        run: |
+          PROPOSAL_PATH="${{ github.event.inputs.proposal_path }}"
+          if [ ! -f "${PROPOSAL_PATH}" ]; then
+            echo "Proposal JSON not found: ${PROPOSAL_PATH}" >&2
+            exit 1
+          fi
+          echo "[Sho] Found proposal JSON: ${PROPOSAL_PATH}"
+          # 将来ここで proposal.json を LLM に渡す。
+          cp "${PROPOSAL_PATH}" proposal.json
+
+      - name: Generate doc_update_review_v1 (placeholder)
+        id: generate_review
+        run: |
+          # TODO: ここを Sho (LLM) による本物のレビュー生成に差し替える。
+          # v1 ではワークフローの枠を先に作るため、ダミーの doc_update_review_v1.json を生成する。
+          PROPOSAL_PATH="${{ github.event.inputs.proposal_path }}"
+          PROJECT_ID="${{ github.event.inputs.project_id }}"
+          NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+          cat > doc_update_review_v1.json << JSON
+{
+  "schema_version": "doc_update_review_v1",
+  "project_id": "${PROJECT_ID}",
+  "proposal_ref": "${PROPOSAL_PATH}",
+  "generated_at": "${NOW}",
+  "overall_assessment": {
+    "summary": "placeholder review by Sho v1: このレビューは枠組みテスト用のダミーです。",
+    "risk_level": "low"
+  },
+  "update_judgements": [
+    {
+      "target_path": "STATE/vpm-mini/current_state.md",
+      "section_hint": "n/a (placeholder)",
+      "decision": "accept",
+      "reason": "placeholder: 本番実装では proposal.json を解析して judgement を生成します。"
+    }
+  ],
+  "notes": [
+    "この doc_update_review_v1.json は Doc Update Review (Sho) workflow v1 の枠組みテスト用です。",
+    "将来、Sho は proposal.json の中身を読み、各 updates に対する judgement を生成します。"
+  ]
+}
+JSON
+
+          echo "[Sho] Wrote placeholder doc_update_review_v1.json"
+
+      - name: Upload review JSON as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: doc_update_review_v1_${{ github.event.inputs.project_id }}
+          path: doc_update_review_v1.json


### PR DESCRIPTION
Add .github/workflows/doc_update_review.yml for Sho (doc_update_reviewer). This workflow reads a doc_update_proposal_v1 JSON (proposal_path), generates a placeholder doc_update_review_v1.json, and uploads it as an artifact. In the future, the placeholder step will be replaced by a real LLM-based review for Sho.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

