### PR TITLE
Test: add dummy doc_update_proposal for Sho v1

### DIFF
--- a/reports/doc_update_proposals/2025-11-24-vpm-mini.json
+++ b/reports/doc_update_proposals/2025-11-24-vpm-mini.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "doc_update_proposal_v1",
+  "project_id": "vpm-mini",
+  "generated_at": "2025-11-24T12:00:00+09:00",
+  "updates": [],
+  "no_change": [],
+  "notes": [
+    "Sho v1 workflow scaffold test 用のダミー doc_update_proposal です。実際の更新提案は含まれていません。"
+  ]
+}


### PR DESCRIPTION
Add reports/doc_update_proposals/2025-11-24-vpm-mini.json as a dummy doc_update_proposal_v1 for exercising the Doc Update Review (Sho) workflow v1. This proposal has no real updates and is only used to verify Sho's review pipeline.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
- reports/doc_update_proposals/2025-11-24-vpm-mini.json

