### PR TITLE
CI: enable manual dispatch for Doc Update Review (Sho)

### DIFF
--- a/.github/workflows/doc_update_review.yml
+++ b/.github/workflows/doc_update_review.yml
@@ -12,6 +12,12 @@ on:
         required: true
         default: "reports/doc_update_proposals/2025-11-24-vpm-mini.json"
 
+  # 将来、push や他のトリガーを追加したい場合はここに書く。
+  # 例:
+  # push:
+  #   paths:
+  #     - ".github/workflows/doc_update_review.yml"
+
 jobs:
   review_doc_update_proposal:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update .github/workflows/doc_update_review.yml to include an explicit workflow_dispatch trigger with project_id and proposal_path inputs, so Sho's review workflow can be run from the Actions UI.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

