### PR TITLE
CI: update Doc Update Review Debug inputs to use proposal_path

### DIFF
--- a/.github/workflows/doc_update_review_debug.yml
+++ b/.github/workflows/doc_update_review_debug.yml
@@ -9,9 +9,10 @@ on:
         description: "Target project_id (e.g. vpm-mini, hakone-e2)"
         required: true
         default: "hakone-e2"
-      progress_summary:
-        description: "Summary of the recent progress/change (used as input to PM)"
+      proposal_path:
+        description: "Path to doc_update_proposal_v1 JSON in the repo"
         required: true
+        default: "reports/doc_update_proposals/2025-11-24-vpm-mini.json"
 
 jobs:
   propose_updates:


### PR DESCRIPTION
Adjust .github/workflows/doc_update_review_debug.yml so workflow_dispatch takes project_id and proposal_path (instead of progress_summary), while keeping the jobs body identical to Doc Update Proposal (PM). This isolates whether inputs changes affect workflow_dispatch recognition.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

