### PR TITLE
CI: auto-pick latest proposal for Sho debug

### DIFF
--- a/.github/workflows/doc_update_review_debug.yml
+++ b/.github/workflows/doc_update_review_debug.yml
@@ -23,18 +23,35 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Validate proposal JSON exists
+      - name: Resolve and validate proposal JSON
+        env:
+          PROJECT_ID: ${{ github.event.inputs.project_id }}
+          INPUT_PROPOSAL_PATH: ${{ github.event.inputs.proposal_path }}
         run: |
-          PROPOSAL_PATH="${{ github.event.inputs.proposal_path }}"
+          PROJECT_ID="${PROJECT_ID}"
+          PROPOSAL_PATH="${INPUT_PROPOSAL_PATH}"
+
+          if [ -z "${PROPOSAL_PATH}" ]; then
+            echo "[Sho v1] proposal_path が空なので、最新の proposal を自動検出します..."
+            latest=$(ls -1 "reports/doc_update_proposals/"*"_${PROJECT_ID}".json 2>/dev/null | sort | tail -n 1 || true)
+            if [ -z "${latest}" ]; then
+              echo "No proposal JSON found for project_id=${PROJECT_ID} under reports/doc_update_proposals/" >&2
+              exit 1
+            fi
+            PROPOSAL_PATH="${latest}"
+          fi
+
           if [ ! -f "${PROPOSAL_PATH}" ]; then
             echo "Proposal JSON not found: ${PROPOSAL_PATH}" >&2
             exit 1
           fi
-          echo "[Sho v1] Found proposal JSON: ${PROPOSAL_PATH}"
+
+          echo "[Sho v1] Using proposal JSON: ${PROPOSAL_PATH}"
+          echo "PROPOSAL_PATH=${PROPOSAL_PATH}" >> "$GITHUB_ENV"
 
       - name: Generate doc_update_review_v1 via Python (Sho v1)
         env:
-          PROPOSAL_PATH: ${{ github.event.inputs.proposal_path }}
+          PROPOSAL_PATH: ${{ env.PROPOSAL_PATH }}
           PROJECT_ID: ${{ github.event.inputs.project_id }}
         run: |
           python - << 'PY'


### PR DESCRIPTION
Update .github/workflows/doc_update_review_debug.yml so that when proposal_path is empty, Sho v1 automatically selects the latest doc_update_proposal_v1 JSON for the given project_id under reports/doc_update_proposals/. This reduces manual input and human error; PROPOSAL_PATH is stored in  and used by the Python review step.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

