### PR TITLE
Docs: add Kai-0 JSON examples (lane_status_v1 / what_changed_v1)

### DIFF
--- a/docs/kai/examples/lane_status_v1_example.json
+++ b/docs/kai/examples/lane_status_v1_example.json
@@ -1,0 +1,79 @@
+{
+  "kind": "lane_status_v1",
+  "project_id": "vpm-mini",
+  "lane": {
+    "layer": "layer_b",
+    "name": "doc_update"
+  },
+  "as_of": "2025-11-29T12:00:00+09:00",
+  "cycle": {
+    "latest_cycle_id": "cycle-1",
+    "status": "completed",
+    "started_at": "2025-11-28T00:00:00+09:00",
+    "completed_at": "2025-11-29T00:00:00+09:00",
+    "steps": {
+      "aya": {
+        "status": "completed",
+        "latest_entry": {
+          "blackboard_issue": 841,
+          "blackboard_comment_id": 0,
+          "actions_workflow": "Doc Update Proposal (PM)",
+          "actions_run_id": 0,
+          "artifact_path": "reports/doc_update_proposals/2025-11-28-vpm-mini.json",
+          "updated_at": "2025-11-28T12:00:00+09:00",
+          "summary": "STATE/vpm-mini/current_state.md の Layer B セクション更新案を生成。"
+        }
+      },
+      "sho": {
+        "status": "completed",
+        "latest_entry": {
+          "actions_workflow": "Doc Update Review (Sho v2)",
+          "actions_run_id": 0,
+          "artifact_path": "reports/doc_update_reviews/2025-11-28-vpm-mini.json",
+          "review_mode": "auto_accept_v1",
+          "risk": "low",
+          "updated_at": "2025-11-28T13:00:00+09:00",
+          "summary": "提案を auto-accept v1 (risk=low) と判定。"
+        }
+      },
+      "tsugu": {
+        "status": "completed",
+        "latest_entry": {
+          "apply_mode": "codex_apply",
+          "prs": [
+            {
+              "number": 847,
+              "title": "Apply: Layer B rules v1 (STATE)",
+              "state": "merged"
+            },
+            {
+              "number": 849,
+              "title": "Apply: Evidence & Gap update",
+              "state": "merged"
+            }
+          ],
+          "updated_at": "2025-11-29T10:00:00+09:00",
+          "summary": "STATE/vpm-mini/current_state.md を提案どおり置き換え。"
+        }
+      }
+    }
+  },
+  "state_view": {
+    "state_file": "STATE/vpm-mini/current_state.md",
+    "section_anchor": "#layer-b-doc-update-v1",
+    "digest": "Layer B 最小サイクル（Aya→Sho→Tsugu/Apply→STATE更新）が cycle-1 まで完了。",
+    "known_gaps": [
+      "Gen / PM Snapshot への連携は未実装。",
+      "Kai 自身はまだ ChatGPT 上の概念のみ。"
+    ]
+  },
+  "next_suggested_actions": [
+    {
+      "id": "b-002",
+      "title": "Gen / PM Snapshot を黒板レーンに接続。",
+      "owner": "Kai",
+      "priority": "M",
+      "suggested_lane": "pm_snapshot"
+    }
+  ]
+}

--- a/docs/kai/examples/what_changed_v1_example.json
+++ b/docs/kai/examples/what_changed_v1_example.json
@@ -1,0 +1,92 @@
+{
+  "kind": "what_changed_v1",
+  "project_id": "vpm-mini",
+  "time_window": {
+    "from": "2025-11-22",
+    "to": "2025-11-29"
+  },
+  "highlights": [
+    {
+      "rank": 1,
+      "category": "layer_b",
+      "title": "Layer B / Doc Update レーンの cycle-1 が完了。",
+      "summary": "Aya→Sho→Tsugu/Apply の最小サイクルが初めて一巡し、STATE/vpm-mini/current_state.md に反映された。",
+      "evidence": [
+        {
+          "type": "issue",
+          "id": 841,
+          "title": "[board] doc_update_blackboard_v1",
+          "url": "https://github.com/HirakuArai/vpm-mini/issues/841"
+        },
+        {
+          "type": "pr",
+          "id": 847,
+          "title": "Apply: Layer B rules v1 (STATE)",
+          "url": "https://github.com/HirakuArai/vpm-mini/pull/847"
+        },
+        {
+          "type": "pr",
+          "id": 849,
+          "title": "Apply: Evidence & Gap update",
+          "url": "https://github.com/HirakuArai/vpm-mini/pull/849"
+        },
+        {
+          "type": "state_file",
+          "path": "STATE/vpm-mini/current_state.md",
+          "section": "#layer-b-doc-update-v1"
+        }
+      ]
+    }
+  ],
+  "by_category": {
+    "workflows": [
+      {
+        "name": "Doc Update Proposal (PM)",
+        "runs": 1,
+        "last_run_status": "success",
+        "last_run_at": "2025-11-28T12:00:00+09:00",
+        "notes": "黒板 entry をトリガーに doc_update_proposal_v1 を生成。"
+      },
+      {
+        "name": "Doc Update Review (Sho v2)",
+        "runs": 1,
+        "last_run_status": "success",
+        "last_run_at": "2025-11-28T13:00:00+09:00",
+        "notes": "auto-accept v1 (risk=low) が動作。"
+      }
+    ],
+    "prs": [
+      {
+        "number": 847,
+        "title": "Apply: Layer B rules v1 (STATE)",
+        "state": "merged",
+        "merged_at": "2025-11-29T10:00:00+09:00",
+        "impact": "STATE の Layer B 運用ルールを v1 に更新。"
+      },
+      {
+        "number": 849,
+        "title": "Apply: Evidence & Gap update",
+        "state": "merged",
+        "merged_at": "2025-11-29T10:10:00+09:00",
+        "impact": "Gap と Evidence を最新の認識に更新。"
+      }
+    ],
+    "state_docs": [
+      {
+        "path": "STATE/vpm-mini/current_state.md",
+        "summary": "Layer B セクションを追加／更新し、Gap/Tasks/Evidence を整理。",
+        "impact_level": "high"
+      }
+    ]
+  },
+  "risks": [
+    {
+      "id": "r-001",
+      "summary": "Gen / PM Snapshot がまだ Layer B cycle-1 完了を反映していない。",
+      "suggested_action": "次回 PM Snapshot で C/G/δ に cycle-1 完了を取り込む。"
+    }
+  ],
+  "open_questions": [
+    "Layer B 以外のレーンをいつ Kai-0 の対象に広げるか？"
+  ]
+}


### PR DESCRIPTION
## Summary\n- add two Kai-0 JSON examples aligned with docs/kai/kai_io_spec_v1.md\n- examples represent vpm-mini Layer B / doc_update cycle-1 outputs for lane_status_v1 and what_changed_v1\n- documentation only; no workflow or runtime changes\n\n## Testing\n- not needed (docs only)\n

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

