### PR TITLE
Docs: apply 2025-11-30 doc_update_review_v1 to STATE and Layer B flow

### DIFF
--- a/STATE/vpm-mini/current_state.md
+++ b/STATE/vpm-mini/current_state.md
@@ -1,17 +1,17 @@
 # STATE: vpm-mini / current_state
 
-最終更新: 2025-11-23 by 啓
+最終更新: 2025-11-30 by 啓
 
 ## 1. Snapshot（C / G / δ）
 
 ### 1.1 Current（C: 現在地）
 
 - フェーズ: Phase 2。インフラ（VM/GKE）を一旦縮退し、「GitHub + LLM の PM Kai v1」にフォーカスしている。
-- プロジェクトの SSOT は `docs/projects/vpm-mini/project_definition.md` に定義済み（PR #800）。`STATE/vpm-mini/current_state.md` と `reports/vpm-mini/2025-11-23_weekly.md` に 2025-11-23 時点の C/G/δ と進捗を記録（PR #801, #802, #803, #810）。
+- プロジェクトの SSOT は `docs/projects/vpm-mini/project_definition.md` に定義済み（PR #800）。`STATE/vpm-mini/current_state.md` と `reports/vpm-mini/2025-11-23_weekly.md`, `reports/vpm-mini/2025-11-30_weekly.md` に C/G/δ と進捗を記録（PR #801, #802, #803, #810 ほか）。
 - `docs/pm/pm_snapshot_v1_spec.md` に pm_snapshot_v1 の仕様と標準質問を定義し、`.github/workflows/pm_snapshot.yml` から手動実行で Snapshot を生成可能（PR #804, #805, #806, #807, #809）。
 - レイヤーB最小更新フロー v1 を `docs/pm/layer_b_update_flow.md` に定義。`docs/pm/doc_update_pipeline_v1.md` と `docs/pm/doc_update_review_v1_spec.md` を追加し、doc_update_proposal_v1 の提案〜レビューの枠組みを整備（PR #817, #818）。
 - 5セル観点の整理として `docs/pm/roles_v1.md` を追加し、Kai / Aya / Sho などのロールと5セル構成を定義（PR #820）。また、`docs/pm/blackboard_v1_draft.md` を追加し、Aya↔Sho の伝言形式（「駅の黒板」プロトコル）を整理（PR #821）。
-- Sho v1 の Doc Update Review Debug ワークフローを整備し、`doc_update_review_v1.json` を Python で生成できる体制を構築（PR #822〜#835）。今後、Aya→Sho→Human→反映 のループを vpm-mini で実際に回していく方針。
+- Sho v1 の Doc Update Review Debug ワークフローを整備し、`doc_update_review_v1.json` を Python で生成できる体制を構築（PR #822〜#835）。vpm-mini で Aya→Sho→Human→反映 の最小サイクルを次週以降に実運用予定。
 
 ### 1.2 Goals（G: ゴール）
 
@@ -30,7 +30,7 @@
 ### 1.3 Gap（δ）
 
 - pm_snapshot_v1 の仕様とレイヤーB最小更新フロー v1 は定義済みだが、vpm-mini での実サイクル運用（doc_update_proposal_v1 → STATE/weekly 反映 → 次の Snapshot）の実践が未了。
-- 運用ルール（トリガー、責任分担、採否基準）の軽量版は本 STATE に v1 として追記済み。今後、実運用を通じてチューニング（閾値や例外時の扱い）を行う必要がある。
+- 運用ルールの軽量版は本 STATE にドラフトとして追記済み。`docs/pm/doc_update_review_v1_spec.md` との参照関係や例外時の扱いなど、実運用を通じたチューニングが必要。
 - Sho v1 Debug ワークフローにより `doc_update_review_v1.json` 生成の検証環境は整ったが、vpm-mini 向けの定常運用（Actions からの起動、アサイン、レビュー動線）に組み込む段取りが未整備。
 - PR 自動化（pm_snapshot 実行直後に更新案ブランチを作成する最小フロー）の設計と検証が未完。
 - マルチプロジェクト展開に向けた他プロジェクトの project_definition / STATE / reports 整備は未着手（hakone-e2 は試行のみ）。
@@ -44,6 +44,7 @@
 - [ ] **T-INF-1:** VM/GKE 縮退後の GCP インベントリを月次レベルで確認する軽い仕組み（レポート or 手動チェック）を検討する（優先度はレイヤーBより低い）。
 - [ ] **T-DOC-1:** doc_update_proposal_v1 を vpm-mini に適用し、STATE/weekly 更新案 → 手動PR → マージの1サイクルを実施する（docs/pm/doc_update_pipeline_v1.md・docs/pm/doc_update_review_v1_spec.md に準拠。適用には `docs/ops/codex_brief_apply_doc_update_v1.md` を使用）（優先度: 高、owner: 啓、期限: 2025-12-07 目安）。
 - [ ] **T-AUTO-1:** pm_snapshot 実行後に更新案ブランチを切る最小の自動PRフロー案（設計メモ）を作成する（owner: 啓、期限: 2025-12-07 目安）。
+- [ ] **T-WF-1:** Sho v1 Debug ワークフローを定常運用に組み込む（Actions 起動・アサイン・レビュー動線の整備）（owner: 啓、期限: 2025-12-07 目安）。
 ## レイヤーB（記録・構造化ループ）のゴールとステップ
 
 **ゴール（Layer B）**

--- a/docs/pm/layer_b_update_flow.md
+++ b/docs/pm/layer_b_update_flow.md
@@ -134,10 +134,11 @@ Kai に求めるアウトプット（テキスト）:
 
 というセミ自動の形から始める。
 
-## 6. 現時点のステータス（2025-11-23）
+## 6. 現時点のステータス（2025-11-30）
 
 - PM Snapshot 仕様（pm_snapshot_v1）と標準質問は `docs/pm/pm_snapshot_v1_spec.md` に定義済み（PR #804, #809）。
 - vpm-mini の current_state ベースラインは `STATE/vpm-mini/current_state.md` に反映済み（PR #811）。
 - `pm_snapshot.yml` ワークフローから、vpm-mini に対する PM Snapshot を手動で生成可能（PR #805, #806, #807）。
-- 本ドキュメント（layer_b_update_flow）は、レイヤーBの「設計書 v1」として位置づける。今後、実際のループを回しながら必要に応じて更新していく。
+- 5セル観点の `roles_v1` と Aya↔Sho の `blackboard` ドラフトを追加（PR #820, #821）。
+- Sho v1 の Doc Update Review Debug ワークフローを整備し、`doc_update_review_v1.json` を生成できる検証基盤が整った（PR #822〜#835）。
 - hakone-e2 プロジェクトにて、doc_update_proposal_v1 → STATE/weekly 反映の1サイクルを実施し、手順の妥当性を予備確認済み。vpm-mini への適用はこれから。


### PR DESCRIPTION
## Summary\n- applied doc_update_review_v1 (2025-11-30) to STATE/vpm-mini/current_state.md and docs/pm/layer_b_update_flow.md\n- refreshed Current/Gap/Active Focus with 2025-11-30 snapshot context and added Sho workflow task; updated Layer B status section to 2025-11-30\n- implements auto-accepted doc_update_review_v1.json; behavior unchanged\n\n## References\n- reports/doc_update_reviews/19789185330/doc_update_review_v1.json (downloaded via gh run download)\n\n## Testing\n- not run (docs only)\n

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

