### PR TITLE
Fix: Tsugu apply uses --head with gh pr create

### DIFF
--- a/tools/tsugu/apply_doc_update_v1.py
+++ b/tools/tsugu/apply_doc_update_v1.py
@@ -130,6 +130,8 @@ def create_branch_commit_pr(branch: str, run_id: str, files: List[str]):
             f"Docs: apply doc_update_review_v1 (run {run_id}) to STATE/docs",
             "--body",
             "\n".join(body_lines),
+            "--head",
+            branch,
         ]
     )
 


### PR DESCRIPTION
## Summary\n- add --head <branch> to gh pr create in tools/tsugu/apply_doc_update_v1.py\n- ensures Actions runs can push branch and open PR without manual push step\n- no other behavior changes\n\n## Testing\n- not run (helper change only)\n

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

