### PR TITLE
Fix: Tsugu apply pushes branch before PR creation

### DIFF
--- a/tools/tsugu/apply_doc_update_v1.py
+++ b/tools/tsugu/apply_doc_update_v1.py
@@ -114,6 +114,7 @@ def create_branch_commit_pr(branch: str, run_id: str, files: List[str]):
     run_cmd(
         ["git", "commit", "-m", f"docs(state): apply doc_update_review_v1 run {run_id}"]
     )
+    run_cmd(["git", "push", "-u", "origin", branch])
 
     body_lines = [
         f"Applied doc_update_review_v1 from Actions run `{run_id}`.",
@@ -132,6 +133,8 @@ def create_branch_commit_pr(branch: str, run_id: str, files: List[str]):
             "\n".join(body_lines),
             "--head",
             branch,
+            "--base",
+            "main",
         ]
     )
 


### PR DESCRIPTION
## Summary\n- in apply_doc_update_v1.py, push the branch before calling gh pr create and set --base main\n- avoids GraphQL errors (head/base sha blank, no commits) seen when PR was created before push\n- no changes to apply logic or safety checks\n\n## Testing\n- not run (helper change only)\n

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

