### PR TITLE
Feat: Sho emits full-file final_content for doc_update_review_v1

### DIFF
--- a/.github/workflows/doc_update_review_sho.yml
+++ b/.github/workflows/doc_update_review_sho.yml
@@ -136,6 +136,8 @@ jobs:
         id: generate_review
         env:
           PROPOSAL_PATH: ${{ steps.download_proposal.outputs.proposal_path }}
+          # pragma: allowlist secret
+          OPENAI_API_KEY_REVIEW: ${{ secrets.OPENAI_API_KEY }} # pragma: allowlist secret
         run: |
           set -euo pipefail
 
@@ -145,13 +147,45 @@ jobs:
           import os
           import pathlib
           import sys
+          import urllib.request
 
           proposal_path = pathlib.Path(os.environ.get("PROPOSAL_PATH") or "doc_update_proposal_v1.json")
+          api_key = os.environ.get("OPENAI_API_KEY_REVIEW")
           if not proposal_path.exists():
             print(f"Proposal JSON not found: {proposal_path}", file=sys.stderr)
             sys.exit(1)
+          if not api_key:
+            print("OPENAI_API_KEY is required for Sho review", file=sys.stderr)
+            sys.exit(1)
 
           proposal = json.loads(proposal_path.read_text(encoding="utf-8"))
+
+          def call_openai(system: str, user: str) -> str:
+            payload = {
+              "model": "gpt-4o",
+              "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+              ],
+              "temperature": 0.2,
+              "max_tokens": 2000,
+            }
+            data = json.dumps(payload).encode("utf-8")
+            req = urllib.request.Request(
+              "https://api.openai.com/v1/chat/completions",
+              data=data,
+              headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {api_key}",
+              },
+            )
+            with urllib.request.urlopen(req, timeout=90) as resp:
+              body = resp.read().decode("utf-8")
+            try:
+              return json.loads(body)["choices"][0]["message"]["content"]
+            except Exception as exc:  # noqa: BLE001
+              print(f"OpenAI response parse error: {body}", file=sys.stderr)
+              raise exc
 
           updates = proposal.get("updates", [])
           per_path = {}
@@ -173,13 +207,29 @@ jobs:
               or target.get("after")
               or ""
             )
+            notes = u.get("reason") or ""
+
+            system_prompt = (
+              "You are Sho (Doc Update Review). Given the current file and Aya's proposal snippet, "
+              "produce the complete updated file content. Preserve headings and unrelated sections unless change is implied. "
+              "Return only the full updated file text; no JSON or fences."
+            )
+            user_prompt = (
+              f"target_path: {path}\n"
+              f"current_file:\n{current_content}\n\n"
+              f"proposal_snippet:\n{suggestion}\n\n"
+              f"notes:\n{notes}\n\n"
+              "Write the full updated file content reflecting the proposal and notes. Keep structure, only adjust what is needed."
+            )
+
+            final_content = call_openai(system_prompt, user_prompt).strip()
 
             ru = dict(u)
             ru["status"] = "accept"
             ru["risk"] = "low"
             ru["reviewer_comment"] = "v1 auto-accept by Sho; human review still recommended."
             ru["change_type"] = "replace_whole_file"
-            ru["final_content"] = suggestion if suggestion else current_content
+            ru["final_content"] = final_content or current_content
 
             # ensure one entry per path (latest wins if duplicates)
             ru["target"] = {"path": path, **{k: v for k, v in target.items() if k != "path"}}

--- a/docs/pm/doc_update_review_v1_spec.md
+++ b/docs/pm/doc_update_review_v1_spec.md
@@ -148,7 +148,7 @@ Tsugu が機械適用する際に参照するフィールド。各ファイル�
 - change_type (string, required)  
   - v1 は `"replace_whole_file"` のみ
 - final_content (string, required)  
-  - 適用後の完成形全文。見出しや箇条書きなど既存構造を保った上で、提案を反映した本文。
+  - 適用後の完成形全文。見出しや箇条書きなど既存構造を保った上で、提案を反映した完成形（replace_whole_file の場合はファイル全体が入る）。
 - risk (string, required)  
   - `"low"` でないものは Tsugu v1 では適用しない
 - reviewer_comment (string, optional)  


### PR DESCRIPTION
## Summary\n- Sho doc_update_review_v1 now calls OpenAI to generate full-file final_content per target, using current file + Aya proposal snippet + notes; change_type remains replace_whole_file\n- spec updated to clarify final_content is the complete updated file\n- Tsugu apply untouched; applies full content as before\n\n## Testing\n- not run (workflow uses OpenAI API)\n

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

