### PR TITLE
Feat: Tsugu apply labels PRs with evidence

### DIFF
--- a/tools/tsugu/apply_doc_update_v1.py
+++ b/tools/tsugu/apply_doc_update_v1.py
@@ -135,6 +135,8 @@ def create_branch_commit_pr(branch: str, run_id: str, files: List[str]):
             branch,
             "--base",
             "main",
+            "--label",
+            "evidence",
         ]
     )
 


### PR DESCRIPTION
## Summary\n- update tools/tsugu/apply_doc_update_v1.py to call gh pr create with --label evidence\n- ensures evidence_pr_checks jobs (evidence-dod, healthcheck, k8s-validate, knative-ready, test-and-artifacts) run on Tsugu doc_update_apply PRs to satisfy required checks\n- behavior otherwise unchanged\n\n## Testing\n- not run (helper change only)\n

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

