### PR TITLE
Fix: CI evidence checks run on Tsugu apply PRs

### DIFF
--- a/.github/workflows/evidence_pr_checks.yml
+++ b/.github/workflows/evidence_pr_checks.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize, labeled, reopened]
 jobs:
   evidence-dod:
-    if: contains(github.event.pull_request.labels.*.name, 'evidence')
+    if: contains(github.event.pull_request.labels.*.name, 'evidence') || startsWith(github.head_ref, 'feature/doc-update-apply-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -13,22 +13,22 @@ jobs:
           test -f reports/daily.md
           grep -q '^FOOTER:' reports/daily.md
   healthcheck:
-    if: contains(github.event.pull_request.labels.*.name, 'evidence')
+    if: contains(github.event.pull_request.labels.*.name, 'evidence') || startsWith(github.head_ref, 'feature/doc-update-apply-')
     runs-on: ubuntu-latest
     steps:
       - run: echo ok
   k8s-validate:
-    if: contains(github.event.pull_request.labels.*.name, 'evidence')
+    if: contains(github.event.pull_request.labels.*.name, 'evidence') || startsWith(github.head_ref, 'feature/doc-update-apply-')
     runs-on: ubuntu-latest
     steps:
       - run: echo ok
   knative-ready:
-    if: contains(github.event.pull_request.labels.*.name, 'evidence')
+    if: contains(github.event.pull_request.labels.*.name, 'evidence') || startsWith(github.head_ref, 'feature/doc-update-apply-')
     runs-on: ubuntu-latest
     steps:
       - run: echo ok
   test-and-artifacts:
-    if: contains(github.event.pull_request.labels.*.name, 'evidence')
+    if: contains(github.event.pull_request.labels.*.name, 'evidence') || startsWith(github.head_ref, 'feature/doc-update-apply-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary\n- relax evidence_pr_checks job conditions to run when PR is labeled evidence or head_ref starts with feature/doc-update-apply- (Tsugu apply)\n- ensures required checks (evidence-dod, healthcheck, k8s-validate, knative-ready, test-and-artifacts) execute on Tsugu doc_update_apply PRs with evidence label\n- no other workflow logic changed\n\n## Testing\n- not run (CI config change only)\n

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

