### PR TITLE
Chore: rename Doc Update Proposal flow to Doc Update Proposal (Aya)

### DIFF
--- a/.github/workflows/doc_update_proposal.yml
+++ b/.github/workflows/doc_update_proposal.yml
@@ -1,6 +1,6 @@
 # cell_roles: watcher, curator, planner, synthesizer
 
-name: Doc Update Proposal (PM)
+name: Doc Update Proposal (Aya)
 
 on:
   workflow_dispatch:

--- a/docs/kai/examples/lane_status_v1_example.json
+++ b/docs/kai/examples/lane_status_v1_example.json
@@ -17,7 +17,7 @@
         "latest_entry": {
           "blackboard_issue": 841,
           "blackboard_comment_id": 0,
-          "actions_workflow": "Doc Update Proposal (PM)",
+          "actions_workflow": "Doc Update Proposal (Aya)",
           "actions_run_id": 0,
           "artifact_path": "reports/doc_update_proposals/2025-11-28-vpm-mini.json",
           "updated_at": "2025-11-28T12:00:00+09:00",

--- a/docs/kai/examples/what_changed_v1_example.json
+++ b/docs/kai/examples/what_changed_v1_example.json
@@ -41,7 +41,7 @@
   "by_category": {
     "workflows": [
       {
-        "name": "Doc Update Proposal (PM)",
+        "name": "Doc Update Proposal (Aya)",
         "runs": 1,
         "last_run_status": "success",
         "last_run_at": "2025-11-28T12:00:00+09:00",

--- a/docs/kai/kai_assist_spec_v1.md
+++ b/docs/kai/kai_assist_spec_v1.md
@@ -76,7 +76,7 @@ context_header: repo=vpm-mini / branch=main / phase=Phase 2 (Kai-0 / Kai-assist 
     - "レイヤーBサイクルの説明文は、『pm_snapshot → 現実のアクション → Aya/Sho/doc_update → PR → STATE追随』という形に書き換える。"
 
 ## 5. task_type: inspect_doc_update_proposal_flow_v1
-- 目的: Doc Update Proposal (PM) workflow と黒板読み取りロジックを調査し、黒板 Issue #841 のどのエントリをどう選び、どのフィールドをプロンプトに使っているかを確認する。payload_ref / target_docs / change_intent を見落としていないか、今回のような manual_note リクエストが拾われなかった理由と修正案を findings / recommendations で返す。
+- 目的: Doc Update Proposal (Aya) workflow と黒板読み取りロジックを調査し、黒板 Issue #841 のどのエントリをどう選び、どのフィールドをプロンプトに使っているかを確認する。payload_ref / target_docs / change_intent を見落としていないか、今回のような manual_note リクエストが拾われなかった理由と修正案を findings / recommendations で返す。
 - 入力 params 想定:
   - target_workflow: "doc_update_proposal_pm"
   - include_files:

--- a/tools/kai/lane_status_v1.py
+++ b/tools/kai/lane_status_v1.py
@@ -33,7 +33,7 @@ def build_lane_status(project_id: str) -> Dict[str, Any]:
                     "latest_entry": {
                         "blackboard_issue": 841,
                         "blackboard_comment_id": 0,
-                        "actions_workflow": "Doc Update Proposal (PM)",
+                        "actions_workflow": "Doc Update Proposal (Aya)",
                         "actions_run_id": 0,
                         "artifact_path": "reports/doc_update_proposals/2025-11-28-vpm-mini.json",
                         "updated_at": "2025-11-28T12:00:00+09:00",


### PR DESCRIPTION
Rename the Doc Update Proposal workflow from "Doc Update Proposal (PM)" to "Doc Update Proposal (Aya)" and update references in docs to follow the actor-based naming convention (Doc Update flows: Aya/Sho/Tsugu; project-level flows: (vpm-mini)).

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

