### PR TITLE
Feat: Aya picks oldest open blackboard request first (FIFO)

### DIFF
--- a/.github/workflows/doc_update_proposal.yml
+++ b/.github/workflows/doc_update_proposal.yml
@@ -88,11 +88,11 @@ jobs:
               return;
             }
 
-            candidates.sort((a, b) => b.ts - a.ts);
-            const latest = candidates[0];
-            core.info(`Selected Aya entry with id: ${latest.entry.id || "unknown"}`);
-            core.setOutput("aya_entry", JSON.stringify(latest.entry));
-            core.setOutput("comment_id", String(latest.comment?.id || latest.entry?.source_comment_id || ""));
+            candidates.sort((a, b) => a.ts - b.ts);
+            const oldest = candidates[0];
+            core.info(`Selected Aya entry with id: ${oldest.entry.id || "unknown"}`);
+            core.setOutput("aya_entry", JSON.stringify(oldest.entry));
+            core.setOutput("comment_id", String(oldest.comment?.id || oldest.entry?.source_comment_id || ""));
             core.setOutput("issue_number", String(issueNumber));
 
       - name: Prepare progress summary from blackboard entry


### PR DESCRIPTION
Update the Doc Update Proposal (Aya) workflow to sort Aya's open doc_update_proposal_request entries by created_at ascending and pick the oldest one (FIFO), so multiple open cards are processed in the order they were created in line with blackboard v1.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

