### PR TITLE
Chore: stop Sho→Aya review_result and use JST timestamps (Doc Update v1)

### DIFF
--- a/.github/workflows/doc_update_review.yml
+++ b/.github/workflows/doc_update_review.yml
@@ -217,7 +217,12 @@ jobs:
               return;
             }
 
-            const now = new Date().toISOString();
+            const jstIso = () => {
+              const now = new Date();
+              const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+              return jst.toISOString().replace(/Z$/, "+09:00");
+            };
+            const now = jstIso();
             entry.status = "done";
             entry.updated_at = now;
 
@@ -252,9 +257,15 @@ jobs:
               return;
             }
 
+            const jstIso = () => {
+              const now = new Date();
+              const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+              return jst.toISOString().replace(/Z$/, "+09:00");
+            };
+
             const requestEntry = JSON.parse(process.env.SHO_ENTRY || "{}");
             const requestId = requestEntry.id || `doc-update-${context.runId}`;
-            const now = new Date().toISOString();
+            const now = jstIso();
 
             const targetDocs = Array.isArray(requestEntry.target_docs) ? requestEntry.target_docs : [];
             const payloadRefs = (requestEntry.payload && requestEntry.payload.refs) || {};
@@ -307,61 +318,3 @@ jobs:
             });
 
             core.info(`Posted Sho→Tsugu apply_request entry with id ${entry.id} on issue ${issueNumber}`);
-
-      - name: Add Sho→Aya blackboard comment
-        uses: actions/github-script@v7
-        env:
-          BOARD_ISSUE_NUMBER: ${{ env.BOARD_ISSUE_NUMBER }}
-          PROJECT_ID: ${{ env.PROJECT_ID }}
-          SHO_ENTRY: ${{ steps.find_sho_entry.outputs.sho_entry }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const issueNumber = parseInt(process.env.BOARD_ISSUE_NUMBER, 10);
-            const projectId = process.env.PROJECT_ID;
-            const shoEntry = JSON.parse(process.env.SHO_ENTRY || "{}");
-            if (!issueNumber) {
-              core.setFailed("BOARD_ISSUE_NUMBER is not set or invalid.");
-              return;
-            }
-            if (!projectId) {
-              core.setFailed("PROJECT_ID is required.");
-              return;
-            }
-            const inReplyTo = shoEntry.id;
-
-            const now = new Date();
-            const id = `${now.toISOString()}_${projectId}_shotoaya_${context.runId}`;
-            const payloadRef = {
-              type: "actions_artifact",
-              workflow_run_id: context.runId,
-              artifact_name: `doc_update_review_v1_${context.runId}`,
-            };
-
-            const entry = {
-              id,
-              from: "Sho",
-              to: "Aya",
-              project_id: projectId,
-              kind: "doc_update_review_result",
-              payload_ref: payloadRef,
-              in_reply_to: inReplyTo,
-              status: "done",
-              created_at: now.toISOString(),
-            };
-
-            const body = [
-              "<!-- blackboard:doc_update_v1 -->",
-              "",
-              "json",
-              JSON.stringify(entry, null, 2),
-            ].join("\n");
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              body,
-            });
-
-            core.info(`Posted Sho→Aya blackboard comment with id: ${id}`);

--- a/.github/workflows/doc_update_review_sho.yml
+++ b/.github/workflows/doc_update_review_sho.yml
@@ -287,7 +287,12 @@ jobs:
               return;
             }
 
-            const now = new Date().toISOString();
+            const jstIso = () => {
+              const now = new Date();
+              const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+              return jst.toISOString().replace(/Z$/, "+09:00");
+            };
+            const now = jstIso();
             entry.status = "done";
             entry.updated_at = now;
 
@@ -322,9 +327,15 @@ jobs:
               return;
             }
 
+            const jstIso = () => {
+              const now = new Date();
+              const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+              return jst.toISOString().replace(/Z$/, "+09:00");
+            };
+
             const requestEntry = JSON.parse(process.env.SHO_ENTRY || "{}");
             const requestId = requestEntry.id || `doc-update-${context.runId}`;
-            const now = new Date().toISOString();
+            const now = jstIso();
 
             const targetDocs = Array.isArray(requestEntry.target_docs) ? requestEntry.target_docs : [];
             const payloadRefs = (requestEntry.payload && requestEntry.payload.refs) || {};
@@ -377,61 +388,3 @@ jobs:
             });
 
             core.info(`Posted Sho→Tsugu apply_request entry with id ${entry.id} on issue ${issueNumber}`);
-
-      - name: Add Sho→Aya blackboard comment
-        uses: actions/github-script@v7
-        env:
-          BOARD_ISSUE_NUMBER: ${{ env.BOARD_ISSUE_NUMBER }}
-          PROJECT_ID: ${{ env.PROJECT_ID }}
-          SHO_ENTRY: ${{ steps.find_sho_entry.outputs.sho_entry }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const issueNumber = parseInt(process.env.BOARD_ISSUE_NUMBER, 10);
-            const projectId = process.env.PROJECT_ID;
-            const shoEntry = JSON.parse(process.env.SHO_ENTRY || "{}");
-            if (!issueNumber) {
-              core.setFailed("BOARD_ISSUE_NUMBER is not set or invalid.");
-              return;
-            }
-            if (!projectId) {
-              core.setFailed("PROJECT_ID is required.");
-              return;
-            }
-            const inReplyTo = shoEntry.id;
-
-            const now = new Date();
-            const id = `${now.toISOString()}_${projectId}_shotoaya_${context.runId}`;
-            const payloadRef = {
-              type: "actions_artifact",
-              workflow_run_id: context.runId,
-              artifact_name: `doc_update_review_v1_${context.runId}`,
-            };
-
-            const entry = {
-              id,
-              from: "Sho",
-              to: "Aya",
-              project_id: projectId,
-              kind: "doc_update_review_result",
-              payload_ref: payloadRef,
-              in_reply_to: inReplyTo,
-              status: "done",
-              created_at: now.toISOString(),
-            };
-
-            const body = [
-              "<!-- blackboard:doc_update_v1 -->",
-              "",
-              "json",
-              JSON.stringify(entry, null, 2),
-            ].join("\n");
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              body,
-            });
-
-            core.info(`Posted Sho→Aya blackboard comment with id: ${id}`);


### PR DESCRIPTION
Stop emitting Sho→Aya doc_update_review_result blackboard comments in the Sho Doc Update Review workflows, and switch all timestamps written by Sho (review_request status update and Tsugu apply_request entries) to Asia/Tokyo (UTC+9) ISO8601 values while keeping FIFO pick/status/apply behavior intact.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

