### PR TITLE
Feat: Gen uses blackboard pm_snapshot_request (Doc Update v1)

### DIFF
--- a/.github/workflows/pm_snapshot.yml
+++ b/.github/workflows/pm_snapshot.yml
@@ -10,6 +10,10 @@ on:
       as_of_date:
         description: "Snapshot date in JST (YYYY-MM-DD)"
         required: true
+      use_blackboard:
+        description: "If true, pick pm_snapshot_request for Gen from the blackboard (doc_update_v1). Set to false to skip blackboard."
+        required: false
+        default: "true"
   push:
     paths:
       - ".github/workflows/pm_snapshot.yml"
@@ -22,9 +26,95 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
+    env:
+      BOARD_ISSUE_NUMBER: "841" # [board] doc_update_blackboard_v1 (Issue #841)
+      PROJECT_ID: ${{ github.event.inputs.project_id || 'vpm-mini' }}
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Find Gen entry from blackboard
+        id: find_gen_entry
+        if: ${{ github.event.inputs.use_blackboard != 'false' }}
+        uses: actions/github-script@v7
+        env:
+          BOARD_ISSUE_NUMBER: ${{ env.BOARD_ISSUE_NUMBER }}
+          PROJECT_ID: ${{ env.PROJECT_ID }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issueNumber = parseInt(process.env.BOARD_ISSUE_NUMBER, 10);
+            const projectId = process.env.PROJECT_ID;
+
+            if (!issueNumber) {
+              core.setFailed("BOARD_ISSUE_NUMBER is not set or invalid.");
+              return;
+            }
+            if (!projectId) {
+              core.setFailed("PROJECT_ID is required.");
+              return;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            const candidates = [];
+            for (const comment of comments) {
+              const body = comment.body || "";
+              if (!body.includes("<!-- blackboard:doc_update_v1 -->")) {
+                continue;
+              }
+              const fenceMatch = body.match(/```json\s*([\s\S]*?)```/m);
+              const inlineMatch = body.match(/json\s+({[\s\S]*})/m);
+              const jsonText = fenceMatch?.[1] ?? inlineMatch?.[1];
+              if (!jsonText) continue;
+
+              let entry;
+              try {
+                entry = JSON.parse(jsonText);
+              } catch (error) {
+                core.info(`Skipping comment ${comment.id}: failed to parse JSON (${error}).`);
+                continue;
+              }
+
+              if (
+                entry?.to === "Gen" &&
+                entry?.kind === "pm_snapshot_request" &&
+                entry?.status === "open" &&
+                entry?.project_id === projectId
+              ) {
+                const createdAt =
+                  entry.created_at ||
+                  entry.ts ||
+                  comment.created_at ||
+                  comment.createdAt ||
+                  comment.updated_at;
+                const ts =
+                  Date.parse(entry.created_at || "") ||
+                  Date.parse(entry.ts || "") ||
+                  Number(entry.ts) ||
+                  Date.parse(createdAt) ||
+                  0;
+                candidates.push({ entry, ts, comment });
+              }
+            }
+
+            if (!candidates.length) {
+              core.setFailed("No open pm_snapshot_request to Gen found on the blackboard.");
+              return;
+            }
+
+            candidates.sort((a, b) => a.ts - b.ts);
+            const oldest = candidates[0];
+            core.info(`Selected Gen entry with id: ${oldest.entry.id || "unknown"}`);
+            core.setOutput("gen_entry", JSON.stringify(oldest.entry));
+            core.setOutput("comment_id", String(oldest.comment?.id || oldest.entry?.source_comment_id || ""));
+            core.setOutput("issue_number", String(issueNumber));
 
       - name: Gather context files
         shell: bash
@@ -142,3 +232,49 @@ jobs:
         with:
           name: pm_snapshot-${{ github.event.inputs.project_id || 'vpm-mini' }}
           path: reports/pm_snapshots/${{ github.event.inputs.as_of_date }}_${{ github.event.inputs.project_id || 'vpm-mini' }}.md
+
+      - name: Mark Gen pm_snapshot_request as done on blackboard
+        if: ${{ success() && steps.find_gen_entry.outputs.gen_entry != '' }}
+        uses: actions/github-script@v7
+        env:
+          GEN_ENTRY: ${{ steps.find_gen_entry.outputs.gen_entry }}
+          COMMENT_ID: ${{ steps.find_gen_entry.outputs.comment_id }}
+          ISSUE_NUMBER: ${{ steps.find_gen_entry.outputs.issue_number }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const entry = JSON.parse(process.env.GEN_ENTRY || "{}");
+            const commentId = parseInt(process.env.COMMENT_ID || "", 10);
+            const issueNumber = parseInt(process.env.ISSUE_NUMBER || "", 10);
+            if (!commentId || Number.isNaN(commentId)) {
+              core.setFailed("comment_id is missing; cannot update blackboard entry.");
+              return;
+            }
+            if (!issueNumber || Number.isNaN(issueNumber)) {
+              core.setFailed("issue_number is missing; cannot update blackboard entry.");
+              return;
+            }
+
+            const jstIso = () => {
+              const now = new Date();
+              const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+              return jst.toISOString().replace(/Z$/, "+09:00");
+            };
+            entry.status = "done";
+            entry.updated_at = jstIso();
+
+            const body = [
+              "<!-- blackboard:doc_update_v1 -->",
+              "",
+              "json",
+              JSON.stringify(entry, null, 2),
+            ].join("\n");
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: commentId,
+              body,
+            });
+
+            core.info(`Updated Gen pm_snapshot_request comment ${commentId} on issue ${issueNumber} to status=done`);


### PR DESCRIPTION
Update the PM Snapshot (vpm-mini) workflow so that Gen 1) picks the oldest open pm_snapshot_request from the blackboard (to=Gen, project_id=vpm-mini), 2) runs the existing pm_snapshot logic, and 3) marks the pm_snapshot_request entry as status=done with JST updated_at, without creating extra result cards.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

