### PR TITLE
Docs: Hana role spec v1 and blackboard roles contract update

### DIFF
--- a/docs/pm/blackboard_roles_contract_v1.md
+++ b/docs/pm/blackboard_roles_contract_v1.md
@@ -395,6 +395,64 @@ C/G/δ/Next の補助情報として扱う可能性はあるが、
 
 本 contract v1 では範囲外とする。
 
+3.6 Hana
+3.6.1 役割
+
+プロジェクトオーナー（僕＋ChatGPT）と AI ロール（Aya / Kai / Gen）の間の
+「黒板レベルの通訳・ルーティング役」を担う。
+
+自分で評価・分岐判断は行わず、kind / target で指定された行き先に
+決まった形式でカードを転送・生成する。
+
+3.6.2 Hana が pick するカード（黒板）
+
+Hana が「自分の仕事」として拾う entry:
+
+- to が "Hana"
+- status が "open"
+- project_id が "vpm-mini"
+- kind が次のいずれか
+  - "hana_task"（僕＋ChatGPT からの依頼。payload.target を持つ）
+  - "pm_snapshot_done"（Gen からの通知。v1 では pm_snapshot_request の status 変更を拾ってもよい）
+  - "hana_analysis_result"（Kai からの調査結果）
+
+allowed_kinds（v1）:
+
+{"hana_task", "pm_snapshot_done", "hana_analysis_result"}
+
+補足: "pm_snapshot_done" は from が "Gen" であることを前提とし、
+to が "Hana" でなくても Gen による status 変更をトリガに拾う運用を許容する。
+
+3.6.3 Hana が生成するカード
+
+- Aya 宛て doc_update_proposal_request:
+  - from: "Hana"
+  - to: "Aya"
+  - project_id: "vpm-mini"
+  - kind: "doc_update_proposal_request"
+  - status: "open"
+  - payload.summary / payload.details は 僕＋ChatGPT から受け取った意図に基づく
+- Kai 宛て hana_to_kai_analysis_request:
+  - from: "Hana"
+  - to: "Kai"
+  - project_id: "vpm-mini"
+  - kind: "hana_to_kai_analysis_request"
+  - status: "open"
+  - payload に対象となる review_run_id や diff 情報への参照を入れる
+- 僕＋ChatGPT 向けの通知:
+  - Hana は Gen snapshot / Kai result / 実行チェーンの evidence を束ねて、
+    「このサイクルの結果セット」を知らせる（黒板カードまたは reports/hana/* を想定）
+
+3.6.4 分岐ルール
+
+Hana 自身は「どこに投げるか」を自分で決めない。
+
+hana_task や hana_to_kai_analysis_request などの kind / target に従い、
+決まった行き先（Aya / Kai / 僕＋ChatGPT）にのみカードを生成する。
+
+v1 では、判断ロジックは 常に外部（僕＋ChatGPT）で行い、
+Hana は指示された target に正確にルーティングするだけ として扱う。
+
 4. Doc Update レーンの「ぐるり一周」例
 
 ここでは、黒板を使った Doc Update レーンが

--- a/docs/pm/hana_role_spec_v1.md
+++ b/docs/pm/hana_role_spec_v1.md
@@ -1,0 +1,88 @@
+Hana ロール仕様 v1
+
+1. 目的
+
+Hana は、プロジェクトオーナー（僕＋ChatGPT）と
+各 AI ロール（Aya / Sho / Tsugu / Gen / Kai-assist）との間の
+「情報の通訳・ルーティング役」を担う。
+
+v1 では、次の制約を前提とする:
+
+- Hana は 評価や再構成は行わない。
+  （Gen の出力の正しさを判定したり、中身を書き直したりはしない）
+- Hana は kind / target に従って決まったルールで動くルーター として振る舞う。
+- 実行レーン (Hana → Aya → Sho → Tsugu → Gen) の「決まったこと」を壊さず、
+  その前後で「誰に何を渡すか」を整理する役割を持つ。
+
+2. 関連レーンの整理
+2.1 実行レーン（Doc Update → Snapshot）
+
+実行レーンは以下の順で動く:
+
+Hana → Aya → Sho → Tsugu → Gen
+
+ここでは、すでに決まった Doc Update サイクルを
+STATE / docs / weekly に反映するための処理のみを扱う。
+
+2.2 思考・議論レーン
+
+プロジェクトの目的・現在地・課題の議論は、
+以下の経路で行う：
+
+僕＋ChatGPT ⇄ Hana ⇄ (Kai-assist / Gen / docs)
+
+ここでは、Hana は「誰から何が出てきたか」を束ね、
+僕＋ChatGPTが参照しやすい形で提示するだけとする（評価は行わない）。
+
+3. Hana の入出力 (I/O)
+3.1 inbound: Hana が受け取るもの
+
+- プロジェクトオーナー（僕＋ChatGPT）からの依頼
+  - 例: Doc Update サイクル開始依頼（今回このテーマで Doc Update を回したい）
+  - 例: Kai に対する調査・分析依頼（このレビュー結果について差分やリスクを整理してほしい）
+- Gen からの通知
+  - pm_snapshot_request が完了したこと
+  - 該当する pm_snapshot ファイルへの参照
+- Kai-assist からの出力
+  - Sho レビューや diff の解析結果
+  - その他、構造化された調査レポート
+
+3.2 outbound: Hana が出すもの
+
+- Aya 向け
+  - kind: doc_update_proposal_request
+  - → Doc Update サイクルを Aya に着火するカード
+- Kai 向け
+  - （必要な場合）kind: hana_to_kai_analysis_request
+  - → 特定の proposal / review / 黒板 entry をもとに分析してほしい、という依頼
+- プロジェクトオーナー（僕＋ChatGPT）向け
+  - Gen のスナップショットや Kai の分析結果を「このサイクルに関する束」として知らせる。
+  - v1では主に場所／リンク／IDの索引を返す。内容を再構成はしない。
+
+4. ルーティングの原則
+
+- v1 では、Hana 自身は「どこに投げるか」を自分で判断しない。
+- 黒板カードや依頼オブジェクトの中に target や kind を明示的に持たせる。
+- 例:
+  - kind: hana_task, target: "Aya"
+    - → Ayaへの doc_update_proposal_request を生成する。
+  - kind: hana_task, target: "Kai"
+    - → Kai-assistへの分析依頼を生成する。
+  - kind: pm_snapshot_done, from: "Gen"
+    - → Hana は「この snapshot がどのサイクルか」を把握し、
+      僕＋ChatGPT に「この結果セット」を知らせるだけとする。
+- Hana は kind / target ごとの決まったルールに従ってのみ動き、
+  自分で「どちらに投げるか」を判断しない。
+
+5. v1 の制約
+
+- Hana は 評価を行わない。
+  - Gen のスナップショットや Sho の提案の是非は、
+    僕＋ChatGPTとの会話の中で判断される。
+- Hana は Doc Update 実行レーン (Aya / Sho / Tsugu / Gen) の中身には介入しない。
+  （ロジックや判断を変えない）
+- Hana の主な責務は:
+  - Doc Update サイクルの起点依頼の受け付け (僕ら→Hana→Aya)
+  - Gen の出力がどのサイクルに対応するかの索引を管理し、
+    僕＋ChatGPTに参照先を教えること
+  - 必要に応じて Kai-assist に調査を依頼し、その結果を僕＋ChatGPTに伝えること


### PR DESCRIPTION
Add docs/pm/hana_role_spec_v1.md to define Hana as a non-evaluating router/relay role for the project owner, Aya, Kai, and Gen; and extend docs/pm/blackboard_roles_contract_v1.md with a Hana section describing which blackboard cards Hana picks and how it routes them based on kind/target.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

