### PR TITLE
Feat: Sho reads blackboard intent and target_docs (Doc Update v1)

### DIFF
--- a/.github/workflows/doc_update_review.yml
+++ b/.github/workflows/doc_update_review.yml
@@ -150,6 +150,8 @@ jobs:
 
       - name: Generate doc update review (auto-accept v1)
         id: generate_review
+        env:
+          SHO_ENTRY: ${{ steps.find_sho_entry.outputs.sho_entry }}
         run: |
           set -euo pipefail
 
@@ -157,9 +159,26 @@ jobs:
           import datetime
           import json
           import pathlib
+          import os
 
           proposal_path = pathlib.Path("doc_update_proposal_v1.json")
           proposal = json.loads(proposal_path.read_text(encoding="utf-8"))
+          sho_entry = json.loads(os.environ.get("SHO_ENTRY", "{}"))
+
+          entry_payload = sho_entry.get("payload") or {}
+          entry_refs = entry_payload.get("refs") or {}
+          entry_target_docs = sho_entry.get("target_docs") or []
+          proposal_target_docs = proposal.get("target_docs") or []
+          combined_target_docs = []
+          for doc in (entry_target_docs + proposal_target_docs):
+            if doc and doc not in combined_target_docs:
+              combined_target_docs.append(doc)
+          source_board_id = (
+            entry_refs.get("source_board_id")
+            or sho_entry.get("source_board_id")
+            or sho_entry.get("id")
+            or ""
+          )
 
           updates = proposal.get("updates", [])
           review_updates = []
@@ -168,13 +187,22 @@ jobs:
             ru["status"] = "accept"
             ru["risk"] = "low"
             ru["reviewer_comment"] = "v1 auto-accept by Sho; human review still recommended."
+            if combined_target_docs:
+              ru["target_docs"] = combined_target_docs
             review_updates.append(ru)
+
+          entry_summary = entry_payload.get("summary") or ""
+          proposal_summary = proposal.get("summary") or ""
+          intent_summary = entry_summary or proposal_summary
 
           review = {
             "schema_version": "doc_update_review_v1",
             "project_id": proposal.get("project_id", ""),
             "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             "decision": "auto_accept_all",
+            "source_board_id": source_board_id,
+            "target_docs": combined_target_docs,
+            "intent_summary": intent_summary,
             "updates": review_updates,
             "no_change": proposal.get("no_change", []),
             "notes": [
@@ -185,6 +213,13 @@ jobs:
           out = pathlib.Path("doc_update_review_v1.json")
           out.write_text(json.dumps(review, ensure_ascii=False, indent=2), encoding="utf-8")
           print(f"Wrote {out}")
+
+          gho = os.environ.get("GITHUB_OUTPUT")
+          if gho:
+            with open(gho, "a", encoding="utf-8") as f:
+              f.write(f"combined_target_docs={json.dumps(combined_target_docs, ensure_ascii=False)}\n")
+              f.write(f"intent_summary={intent_summary}\n")
+              f.write(f"source_board_id={source_board_id}\n")
           PY
 
           echo "review_path=doc_update_review_v1.json" >> "$GITHUB_OUTPUT"
@@ -202,6 +237,9 @@ jobs:
           SHO_ENTRY: ${{ steps.find_sho_entry.outputs.sho_entry }}
           COMMENT_ID: ${{ steps.find_sho_entry.outputs.comment_id }}
           ISSUE_NUMBER: ${{ steps.find_sho_entry.outputs.issue_number }}
+          TARGET_DOCS_JSON: ${{ steps.generate_review.outputs.combined_target_docs }}
+          SOURCE_BOARD_ID: ${{ steps.generate_review.outputs.source_board_id }}
+          INTENT_SUMMARY: ${{ steps.generate_review.outputs.intent_summary }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -248,6 +286,9 @@ jobs:
           SHO_ENTRY: ${{ steps.find_sho_entry.outputs.sho_entry }}
           ISSUE_NUMBER: ${{ steps.find_sho_entry.outputs.issue_number }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
+          TARGET_DOCS_JSON: ${{ steps.generate_review.outputs.combined_target_docs }}
+          SOURCE_BOARD_ID: ${{ steps.generate_review.outputs.source_board_id }}
+          INTENT_SUMMARY: ${{ steps.generate_review.outputs.intent_summary }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -267,7 +308,16 @@ jobs:
             const requestId = requestEntry.id || `doc-update-${context.runId}`;
             const now = jstIso();
 
-            const targetDocs = Array.isArray(requestEntry.target_docs) ? requestEntry.target_docs : [];
+            const targetDocsEnv = process.env.TARGET_DOCS_JSON || "[]";
+            let combinedTargetDocs;
+            try {
+              combinedTargetDocs = JSON.parse(targetDocsEnv);
+            } catch {
+              combinedTargetDocs = [];
+            }
+            const targetDocs =
+              (Array.isArray(combinedTargetDocs) && combinedTargetDocs.length && combinedTargetDocs) ||
+              (Array.isArray(requestEntry.target_docs) ? requestEntry.target_docs : []);
             const payloadRefs = (requestEntry.payload && requestEntry.payload.refs) || {};
             const proposalArtifactName =
               payloadRefs.proposal_artifact_name ||
@@ -277,8 +327,18 @@ jobs:
               payloadRefs.proposal_workflow_run_id ||
               (requestEntry.payload_ref && requestEntry.payload_ref.workflow_run_id) ||
               "";
+            const sourceBoardId =
+              payloadRefs.source_board_id ||
+              process.env.SOURCE_BOARD_ID ||
+              requestEntry.source_board_id ||
+              requestEntry.id ||
+              "";
+            const intentSummary =
+              (requestEntry.payload && requestEntry.payload.summary) ||
+              process.env.INTENT_SUMMARY ||
+              "";
             const summary =
-              (requestEntry.payload && typeof requestEntry.payload.summary === "string" && requestEntry.payload.summary) ||
+              (typeof intentSummary === "string" && intentSummary) ||
               `Apply request based on review ${requestId}`;
 
             const entry = {
@@ -295,7 +355,7 @@ jobs:
                   proposal_workflow_run_id: proposalRunId,
                   review_artifact_name: `doc_update_review_v1_${context.runId}`,
                   review_workflow_run_id: context.runId,
-                  source_board_id: requestId,
+                  source_board_id: sourceBoardId,
                 },
               },
               target_docs: targetDocs,

--- a/.github/workflows/doc_update_review_sho.yml
+++ b/.github/workflows/doc_update_review_sho.yml
@@ -140,6 +140,7 @@ jobs:
           PROPOSAL_PATH: ${{ steps.download_proposal.outputs.proposal_path }}
           # pragma: allowlist secret
           OPENAI_API_KEY_REVIEW: ${{ secrets.OPENAI_API_KEY }} # pragma: allowlist secret
+          SHO_ENTRY: ${{ steps.find_sho_entry.outputs.sho_entry }}
         run: | # pragma: allowlist secret
           set -euo pipefail
 
@@ -152,6 +153,11 @@ jobs:
           import urllib.request
 
           proposal_path = pathlib.Path(os.environ.get("PROPOSAL_PATH") or "doc_update_proposal_v1.json")
+          sho_entry_raw = os.environ.get("SHO_ENTRY", "{}")
+          try:
+            sho_entry = json.loads(sho_entry_raw)
+          except Exception:
+            sho_entry = {}
           api_key = os.environ.get("OPENAI_API_KEY_REVIEW")
           if not proposal_path.exists():
             print(f"Proposal JSON not found: {proposal_path}", file=sys.stderr)
@@ -161,6 +167,26 @@ jobs:
             sys.exit(1)
 
           proposal = json.loads(proposal_path.read_text(encoding="utf-8"))
+
+          entry_payload = sho_entry.get("payload") or {}
+          entry_refs = entry_payload.get("refs") or {}
+          entry_target_docs = sho_entry.get("target_docs") or []
+          proposal_target_docs = proposal.get("target_docs") or []
+          combined_target_docs = []
+          for doc in (entry_target_docs + proposal_target_docs):
+            if doc and doc not in combined_target_docs:
+              combined_target_docs.append(doc)
+          source_board_id = (
+            entry_refs.get("source_board_id")
+            or sho_entry.get("source_board_id")
+            or sho_entry.get("id")
+            or ""
+          )
+          entry_summary = entry_payload.get("summary") or ""
+          entry_details = entry_payload.get("details") or ""
+          proposal_summary = proposal.get("summary") or ""
+          intent_summary = entry_summary or proposal_summary
+          intent_details = entry_details if isinstance(entry_details, str) else ""
 
           def call_openai(system: str, user: str) -> str:
             payload = {
@@ -216,7 +242,16 @@ jobs:
               "produce the complete updated file content. Preserve headings and unrelated sections unless change is implied. "
               "Return only the full updated file text; no JSON or fences."
             )
+            context_lines = []
+            if intent_summary:
+              context_lines.append(f"Intent summary: {intent_summary}")
+            if intent_details:
+              context_lines.append(f"Intent details: {intent_details}")
+            if combined_target_docs:
+              context_lines.append(f"Target docs: {', '.join(combined_target_docs)}")
+            context_block = "\n".join(context_lines)
             user_prompt = (
+              f"Doc update intent/context:\n{context_block}\n\n"
               f"target_path: {path}\n"
               f"current_file:\n{current_content}\n\n"
               f"proposal_snippet:\n{suggestion}\n\n"
@@ -235,6 +270,8 @@ jobs:
 
             # ensure one entry per path (latest wins if duplicates)
             ru["target"] = {"path": path, **{k: v for k, v in target.items() if k != "path"}}
+            if combined_target_docs:
+              ru["target_docs"] = combined_target_docs
             per_path[path] = ru
 
           review_updates = list(per_path.values())
@@ -245,6 +282,9 @@ jobs:
             "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             "decision": "auto_accept_all",
             "review_mode": "auto_accept_v1",
+            "source_board_id": source_board_id,
+            "target_docs": combined_target_docs,
+            "intent_summary": intent_summary,
             "updates": review_updates,
             "no_change": proposal.get("no_change", []),
             "notes": [
@@ -255,6 +295,13 @@ jobs:
           out = pathlib.Path("doc_update_review_v1.json")
           out.write_text(json.dumps(review, ensure_ascii=False, indent=2), encoding="utf-8")
           print(f"Wrote {out}")
+
+          gho = os.environ.get("GITHUB_OUTPUT")
+          if gho:
+            with open(gho, "a", encoding="utf-8") as f:
+              f.write(f"combined_target_docs={json.dumps(combined_target_docs, ensure_ascii=False)}\n")
+              f.write(f"intent_summary={intent_summary}\n")
+              f.write(f"source_board_id={source_board_id}\n")
           PY
 
           echo "review_path=doc_update_review_v1.json" >> "$GITHUB_OUTPUT"
@@ -272,6 +319,9 @@ jobs:
           SHO_ENTRY: ${{ steps.find_sho_entry.outputs.sho_entry }}
           COMMENT_ID: ${{ steps.find_sho_entry.outputs.comment_id }}
           ISSUE_NUMBER: ${{ steps.find_sho_entry.outputs.issue_number }}
+          TARGET_DOCS_JSON: ${{ steps.generate_review.outputs.combined_target_docs }}
+          SOURCE_BOARD_ID: ${{ steps.generate_review.outputs.source_board_id }}
+          INTENT_SUMMARY: ${{ steps.generate_review.outputs.intent_summary }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -318,6 +368,9 @@ jobs:
           SHO_ENTRY: ${{ steps.find_sho_entry.outputs.sho_entry }}
           ISSUE_NUMBER: ${{ steps.find_sho_entry.outputs.issue_number }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
+          TARGET_DOCS_JSON: ${{ steps.generate_review.outputs.combined_target_docs }}
+          SOURCE_BOARD_ID: ${{ steps.generate_review.outputs.source_board_id }}
+          INTENT_SUMMARY: ${{ steps.generate_review.outputs.intent_summary }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -337,7 +390,16 @@ jobs:
             const requestId = requestEntry.id || `doc-update-${context.runId}`;
             const now = jstIso();
 
-            const targetDocs = Array.isArray(requestEntry.target_docs) ? requestEntry.target_docs : [];
+            const targetDocsEnv = process.env.TARGET_DOCS_JSON || "[]";
+            let combinedTargetDocs;
+            try {
+              combinedTargetDocs = JSON.parse(targetDocsEnv);
+            } catch {
+              combinedTargetDocs = [];
+            }
+            const targetDocs =
+              (Array.isArray(combinedTargetDocs) && combinedTargetDocs.length && combinedTargetDocs) ||
+              (Array.isArray(requestEntry.target_docs) ? requestEntry.target_docs : []);
             const payloadRefs = (requestEntry.payload && requestEntry.payload.refs) || {};
             const proposalArtifactName =
               payloadRefs.proposal_artifact_name ||
@@ -347,8 +409,18 @@ jobs:
               payloadRefs.proposal_workflow_run_id ||
               (requestEntry.payload_ref && requestEntry.payload_ref.workflow_run_id) ||
               "";
+            const sourceBoardId =
+              payloadRefs.source_board_id ||
+              process.env.SOURCE_BOARD_ID ||
+              requestEntry.source_board_id ||
+              requestEntry.id ||
+              "";
+            const intentSummary =
+              (requestEntry.payload && requestEntry.payload.summary) ||
+              process.env.INTENT_SUMMARY ||
+              "";
             const summary =
-              (requestEntry.payload && typeof requestEntry.payload.summary === "string" && requestEntry.payload.summary) ||
+              (typeof intentSummary === "string" && intentSummary) ||
               `Apply request based on review ${requestId}`;
 
             const entry = {
@@ -365,7 +437,7 @@ jobs:
                   proposal_workflow_run_id: proposalRunId,
                   review_artifact_name: `doc_update_review_v1_${context.runId}`,
                   review_workflow_run_id: context.runId,
-                  source_board_id: requestId,
+                  source_board_id: sourceBoardId,
                 },
               },
               target_docs: targetDocs,


### PR DESCRIPTION
Update Doc Update Review workflows so that Sho reads Hana/Aya intent (payload.summary/details), target_docs, and source_board_id from the blackboard entry and proposal, injects this context into the review generation, and propagates project_id/source_board_id/target_docs into doc_update_review_v1.json and Sho→Tsugu doc_update_apply_request. No change to Sho's evaluation logic; this only fixes metadata and routing alignment with the blackboard specs.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

