### PR TITLE
Feat: add Info Network Build (Aya) workflow

### DIFF
--- a/.github/workflows/info_network_build_aya.yml
+++ b/.github/workflows/info_network_build_aya.yml
@@ -1,0 +1,260 @@
+name: Info Network Build (Aya)
+
+on:
+  workflow_dispatch:
+    inputs:
+      project_id:
+        description: "Project ID (e.g. vpm-mini)"
+        required: true
+        default: "vpm-mini"
+      board_issue:
+        description: "Blackboard issue number (doc_update_blackboard_v1)"
+        required: true
+        default: "841"
+
+jobs:
+  build_info_network:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Find Aya info_network request from blackboard
+        id: find
+        uses: actions/github-script@v7
+        env:
+          BOARD_ISSUE: ${{ github.event.inputs.board_issue }}
+          PROJECT_ID: ${{ github.event.inputs.project_id }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issueNumber = parseInt(process.env.BOARD_ISSUE, 10);
+            const projectId = process.env.PROJECT_ID;
+
+            if (!issueNumber || Number.isNaN(issueNumber)) {
+              core.setFailed("BOARD_ISSUE is required.");
+              return;
+            }
+            if (!projectId) {
+              core.setFailed("PROJECT_ID is required.");
+              return;
+            }
+
+            core.info(`Searching issue #${issueNumber} for info_network_build_request_v1 (to=Aya, project_id=${projectId})`);
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            let latest = null;
+            for (const comment of comments) {
+              const body = comment.body || "";
+              if (!body.includes("<!-- blackboard:doc_update_v1 -->")) continue;
+
+              const fenceMatch = body.match(/```json\s*([\s\S]*?)```/m);
+              const inlineMatch = body.match(/json\s+({[\s\S]*})/m);
+              const jsonText = fenceMatch?.[1] ?? inlineMatch?.[1];
+              if (!jsonText) continue;
+
+              let entry;
+              try {
+                entry = JSON.parse(jsonText);
+              } catch (err) {
+                core.info(`Skip comment ${comment.id}: JSON parse error ${err}`);
+                continue;
+              }
+
+              if (
+                entry?.to === "Aya" &&
+                entry?.kind === "info_network_build_request_v1" &&
+                entry?.status === "open" &&
+                entry?.project_id === projectId
+              ) {
+                const ts = Date.parse(entry.updated_at || entry.created_at || comment.updated_at || comment.created_at || 0);
+                if (!latest || ts > latest.ts) {
+                  latest = { entry, ts };
+                }
+              }
+            }
+
+            if (!latest) {
+              core.setFailed("No open info_network_build_request_v1 to Aya found.");
+              return;
+            }
+
+            core.setOutput("entry", JSON.stringify(latest.entry));
+            core.setOutput("scope", latest.entry.payload?.scope || "");
+            core.setOutput("summary", latest.entry.payload?.summary || "");
+            core.setOutput("target_docs", JSON.stringify(latest.entry.target_docs || []));
+
+      - name: Build prompt for Aya info_network_builder_v1
+        id: build_prompt
+        run: |
+          ENTRY_JSON='${{ steps.find.outputs.entry }}'
+
+          SPEC_FILE=".tmp_info_network_spec.txt"
+          cat docs/pm/info_network_overview_v1.md > "$SPEC_FILE"
+          echo "" >> "$SPEC_FILE"
+          echo "---- Aya role spec ----" >> "$SPEC_FILE"
+          cat docs/pm/info_network_aya_builder_v1.md >> "$SPEC_FILE"
+
+          echo "$ENTRY_JSON" > .tmp_info_network_request.json
+
+          cat > .tmp_prompt_env.sh <<'EOSH'
+SYSTEM_PROMPT<<'EOS'
+あなたは Aya: info_network_builder_v1 として動作します。
+
+前提:
+- docs/pm/info_network_overview_v1.md で定義された info_node / info_relation v1 のルールに従ってください。
+- docs/pm/info_network_aya_builder_v1.md で定義された Aya の責務と入出力仕様に従ってください。
+- project_id は常に "vpm-mini" とします (v1 の前提)。
+- scope は blackboard entry の payload.scope に従います。
+
+タスク:
+- blackboard entry (info_network_build_request_v1) と、そこに記載された scope / notes / source_texts を読み、scope に対応する info_node と info_relation の案を作成してください。
+- 1ノード = 1 subject × 1 kind × 1文 のルールを守ってください。
+- kind は purpose / expected_state / actual_state / constraint / assumption / decision のいずれかを使ってください。
+- relation type は refines / supports / blocks / depends_on のいずれかを使ってください。
+- 出力は YAML のみとし、以下のトップレベル構造で返してください:
+  project_id: "vpm-mini"
+  scope: "..."
+  nodes: [...]
+  relations: [...]
+
+YAML 以外の説明文やコードフェンスは含めないでください。
+EOS
+USER_PROMPT<<'EOU'
+以下が info_network_overview_v1 / Aya role spec / blackboard entry の内容です。
+
+### info_network_overview_v1 + Aya role spec
+SPEC_PLACEHOLDER
+
+### blackboard entry (info_network_build_request_v1)
+ENTRY_PLACEHOLDER
+
+上記を踏まえて、指定された scope についての info_network_v1 YAML を生成してください。
+EOU
+EOSH
+
+          SPEC_ESCAPED="$(sed 's/^/SPEC: /' "$SPEC_FILE")"
+          ENTRY_ESCAPED="$(sed 's/^/ENTRY: /' .tmp_info_network_request.json)"
+
+          sed -i '' "s|SPEC_PLACEHOLDER|${SPEC_ESCAPED//$'\n'/\\n}|" .tmp_prompt_env.sh
+          sed -i '' "s|ENTRY_PLACEHOLDER|${ENTRY_ESCAPED//$'\n'/\\n}|" .tmp_prompt_env.sh
+
+          cat .tmp_prompt_env.sh
+        shell: bash
+
+      - name: Call OpenAI for info_network build
+        id: call_openai
+        uses: actions/github-script@v7
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs");
+            const content = fs.readFileSync(".tmp_prompt_env.sh", "utf8");
+            const sysMatch = content.match(/SYSTEM_PROMPT<<'EOS'\n([\s\S]*?)\nEOS/);
+            const userMatch = content.match(/USER_PROMPT<<'EOU'\n([\s\S]*?)\nEOU/);
+
+            if (!sysMatch || !userMatch) {
+              core.setFailed("Failed to parse SYSTEM_PROMPT / USER_PROMPT.");
+              return;
+            }
+
+            const systemPrompt = sysMatch[1];
+            const userPrompt = userMatch[1];
+
+            core.info("Calling OpenAI for info_network YAML...");
+
+            const res = await fetch("https://api.openai.com/v1/chat/completions", {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+              },
+              body: JSON.stringify({
+                model: "gpt-4.1-mini",
+                temperature: 0,
+                messages: [
+                  { role: "system", content: systemPrompt },
+                  { role: "user", content: userPrompt },
+                ],
+              }),
+            });
+
+            const data = await res.json();
+            if (!res.ok) {
+              core.error(JSON.stringify(data, null, 2));
+              core.setFailed(`OpenAI API error: ${res.status} ${res.statusText}`);
+              return;
+            }
+
+            const contentText = data?.choices?.[0]?.message?.content;
+            if (!contentText) {
+              core.setFailed("No content returned from OpenAI.");
+              return;
+            }
+
+            fs.writeFileSync("info_network_aya.yml", contentText, "utf8");
+            core.setOutput("yaml", contentText);
+            core.info("Saved info_network_aya.yml");
+
+      - name: Upload info_network YAML artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: info_network_aya_${{ github.run_number }}
+          path: info_network_aya.yml
+
+      - name: Post Aya info_network proposal as comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.inputs.board_issue }}
+        run: |
+          {
+            echo "Aya info_network proposal YAML:"
+            echo ""
+            echo '```yaml'
+            cat info_network_aya.yml
+            echo '```'
+          } > .tmp_comment.txt
+
+          gh issue comment "$ISSUE_NUMBER" -F .tmp_comment.txt
+
+      - name: Mark Aya request as done on blackboard
+        uses: actions/github-script@v7
+        env:
+          BOARD_ISSUE: ${{ github.event.inputs.board_issue }}
+          ENTRY_JSON: ${{ steps.find.outputs.entry }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issueNumber = parseInt(process.env.BOARD_ISSUE, 10);
+            const entry = JSON.parse(process.env.ENTRY_JSON || "{}");
+            if (!issueNumber || Number.isNaN(issueNumber)) {
+              core.setFailed("BOARD_ISSUE is missing.");
+              return;
+            }
+            entry.status = "done";
+            entry.updated_at = new Date().toISOString();
+
+            const body = [
+              "<!-- blackboard:doc_update_v1 -->",
+              "",
+              "json",
+              JSON.stringify(entry, null, 2),
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body,
+            });
+
+            core.info(`Marked entry ${entry.id || ""} as done on issue #${issueNumber}`);


### PR DESCRIPTION
Add info_network_build_aya workflow that reads blackboard info_network_build_request_v1 entries, calls OpenAI (Aya) to build info_network_v1 YAML, uploads it as an artifact, comments the YAML back on the blackboard, and marks the request as done.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

