### PR TITLE
Fix: make Info Network Build (Aya) workflow actually runnable

### DIFF
--- a/.github/workflows/info_network_build_aya.yml
+++ b/.github/workflows/info_network_build_aya.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Find Aya info_network request from blackboard
         id: find
         uses: actions/github-script@v7
+        env:
+          PROJECT_ID: ${{ env.PROJECT_ID }}
+          BOARD_ISSUE_NUMBER: ${{ env.BOARD_ISSUE_NUMBER }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -53,10 +56,9 @@ jobs:
             const candidates = [];
             for (const comment of comments) {
               const body = comment.body || "";
-              if (!body.includes("<!-- blackboard:doc_update_v1 -->")) {
-                continue;
-              }
+              if (!body.includes("<!-- blackboard:doc_update_v1 -->")) continue;
 
+              // doc_update_proposal.yml と同じ fence / inline 両対応の JSON 抽出
               const fenceMatch = body.match(/```json\s*([\s\S]*?)```/m);
               const inlineMatch = body.match(/json\s+({[\s\S]*})/m);
               const jsonText = fenceMatch?.[1] ?? inlineMatch?.[1];
@@ -91,119 +93,97 @@ jobs:
               return;
             }
 
+            // いちばん古い open を採用（doc_update と同じパターン）
             candidates.sort((a, b) => a.ts - b.ts);
             const oldest = candidates[0];
+
             core.info(`Selected Aya info_network entry with id: ${oldest.entry.id || "unknown"}`);
 
             core.setOutput("entry", JSON.stringify(oldest.entry));
-            core.setOutput("comment_id", String(oldest.comment?.id || oldest.entry?.source_comment_id || ""));
             core.setOutput("issue_number", String(issueNumber));
 
-      - name: Build prompt for Aya info_network_builder_v1
-        id: build_prompt
-        run: |
-          ENTRY_JSON='${{ steps.find.outputs.entry }}'
-
-          SPEC_FILE=".tmp_info_network_spec.txt"
-          cat docs/pm/info_network_overview_v1.md > "$SPEC_FILE"
-          echo "" >> "$SPEC_FILE"
-          echo "---- Aya role spec ----" >> "$SPEC_FILE"
-          cat docs/pm/info_network_aya_builder_v1.md >> "$SPEC_FILE"
-
-          echo "$ENTRY_JSON" > .tmp_info_network_request.json
-
-          cat > .tmp_prompt_env.sh <<'EOSH'
-SYSTEM_PROMPT<<'EOS'
-あなたは Aya: info_network_builder_v1 として動作します。
-
-前提:
-- docs/pm/info_network_overview_v1.md で定義された info_node / info_relation v1 のルールに従ってください。
-- docs/pm/info_network_aya_builder_v1.md で定義された Aya の責務と入出力仕様に従ってください。
-- project_id は常に "vpm-mini" とします (v1 の前提)。
-- scope は blackboard entry の payload.scope に従います。
-
-タスク:
-- blackboard entry (info_network_build_request_v1) と、そこに記載された scope / notes / source_texts を読み、scope に対応する info_node と info_relation の案を作成してください。
-- 1ノード = 1 subject × 1 kind × 1文 のルールを守ってください。
-- kind は purpose / expected_state / actual_state / constraint / assumption / decision のいずれかを使ってください。
-- relation type は refines / supports / blocks / depends_on のいずれかを使ってください。
-- 出力は YAML のみとし、以下のトップレベル構造で返してください:
-  project_id: "vpm-mini"
-  scope: "..."
-  nodes: [...]
-  relations: [...]
-
-YAML 以外の説明文やコードフェンスは含めないでください。
-EOS
-USER_PROMPT<<'EOU'
-以下が info_network_overview_v1 / Aya role spec / blackboard entry の内容です。
-
-### info_network_overview_v1 + Aya role spec
-SPEC_PLACEHOLDER
-
-### blackboard entry (info_network_build_request_v1)
-ENTRY_PLACEHOLDER
-
-上記を踏まえて、指定された scope についての info_network_v1 YAML を生成してください。
-EOU
-EOSH
-
-          SPEC_ESCAPED="$(sed 's/^/SPEC: /' "$SPEC_FILE")"
-          ENTRY_ESCAPED="$(sed 's/^/ENTRY: /' .tmp_info_network_request.json)"
-
-          sed -i '' "s|SPEC_PLACEHOLDER|${SPEC_ESCAPED//$'\n'/\\n}|" .tmp_prompt_env.sh
-          sed -i '' "s|ENTRY_PLACEHOLDER|${ENTRY_ESCAPED//$'\n'/\\n}|" .tmp_prompt_env.sh
-
-          cat .tmp_prompt_env.sh
-        shell: bash
-
       - name: Call OpenAI for info_network build
-        id: call_openai
+        id: call
         uses: actions/github-script@v7
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          PROJECT_ID: ${{ env.PROJECT_ID }}
+          ENTRY_JSON: ${{ steps.find.outputs.entry }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require("fs");
-            const content = fs.readFileSync(".tmp_prompt_env.sh", "utf8");
-            const sysMatch = content.match(/SYSTEM_PROMPT<<'EOS'\n([\s\S]*?)\nEOS/);
-            const userMatch = content.match(/USER_PROMPT<<'EOU'\n([\s\S]*?)\nEOU/);
+            const core = require("@actions/core");
 
-            if (!sysMatch || !userMatch) {
-              core.setFailed("Failed to parse SYSTEM_PROMPT / USER_PROMPT.");
-              return;
-            }
+            const entry = JSON.parse(process.env.ENTRY_JSON || "{}");
+            const projectId = process.env.PROJECT_ID || "vpm-mini";
+            const scope = entry.payload?.scope || "";
 
-            const systemPrompt = sysMatch[1];
-            const userPrompt = userMatch[1];
+            const spec = fs.readFileSync("docs/pm/info_network_overview_v1.md", "utf8");
+            const ayaSpec = fs.readFileSync("docs/pm/info_network_aya_builder_v1.md", "utf8");
+            const entryText = JSON.stringify(entry, null, 2);
 
-            core.info("Calling OpenAI for info_network YAML...");
+            const systemPrompt = [
+              "あなたは Aya: info_network_builder_v1 として動作します。",
+              "",
+              "前提:",
+              "- docs/pm/info_network_overview_v1.md で定義された info_node / info_relation v1 のルールに従ってください。",
+              "- docs/pm/info_network_aya_builder_v1.md で定義された Aya の責務と入出力仕様に従ってください。",
+              `- project_id は常に \"${projectId}\" とします (v1 の前提)。`,
+              "- scope は blackboard entry の payload.scope に従います。",
+              "",
+              "タスク:",
+              "- blackboard entry (info_network_build_request_v1) と、そこに記載された scope / notes / source_texts を読み、scope に対応する info_node と info_relation の案を作成してください。",
+              "- 1ノード = 1 subject × 1 kind × 1文 のルールを守ってください。",
+              "- kind は purpose / expected_state / actual_state / constraint / assumption / decision のいずれかを使ってください。",
+              "- relation type は refines / supports / blocks / depends_on のいずれかを使ってください。",
+              "- 出力は YAML のみとし、以下のトップレベル構造で返してください:",
+              `  project_id: \"${projectId}\"`,
+              `  scope: \"${scope}\"`,
+              "  nodes: [...]",
+              "  relations: [...]",
+              "",
+              "YAML 以外の説明文やコードフェンスは含めないでください。"
+            ].join("\n");
+
+            const userPrompt = [
+              "### info_network_overview_v1 + Aya role spec",
+              "",
+              spec,
+              "",
+              ayaSpec,
+              "",
+              "### blackboard entry (info_network_build_request_v1)",
+              "",
+              entryText,
+              "",
+              "上記を踏まえて、指定された scope についての info_network_v1 YAML を生成してください。"
+            ].join("\n");
 
             const res = await fetch("https://api.openai.com/v1/chat/completions", {
               method: "POST",
               headers: {
                 "Content-Type": "application/json",
-                Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+                "Authorization": `Bearer ${process.env.OPENAI_API_KEY}`
               },
               body: JSON.stringify({
                 model: "gpt-4.1-mini",
                 temperature: 0,
                 messages: [
                   { role: "system", content: systemPrompt },
-                  { role: "user", content: userPrompt },
-                ],
-              }),
+                  { role: "user", content: userPrompt }
+                ]
+              })
             });
 
-            const data = await res.json();
             if (!res.ok) {
-              core.error(JSON.stringify(data, null, 2));
-              core.setFailed(`OpenAI API error: ${res.status} ${res.statusText}`);
+              const err = await res.text();
+              core.setFailed(`OpenAI API error: ${res.status} ${res.statusText}: ${err}`);
               return;
             }
 
-            const contentText = data?.choices?.[0]?.message?.content;
+            const data = await res.json();
+            const contentText = data.choices?.[0]?.message?.content;
             if (!contentText) {
               core.setFailed("No content returned from OpenAI.");
               return;
@@ -211,7 +191,6 @@ EOSH
 
             fs.writeFileSync("info_network_aya.yml", contentText, "utf8");
             core.setOutput("yaml", contentText);
-            core.info("Saved info_network_aya.yml");
 
       - name: Upload info_network YAML artifact
         uses: actions/upload-artifact@v4
@@ -221,61 +200,45 @@ EOSH
 
       - name: Post Aya info_network proposal as comment
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ steps.find.outputs.issue_number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          ISSUE="${{ steps.find.outputs.issue_number }}"
           {
-            echo "Aya info_network proposal YAML:"
-            echo ""
+            echo 'Aya info_network proposal YAML:'
+            echo
             echo '```yaml'
             cat info_network_aya.yml
             echo '```'
           } > .tmp_comment.txt
 
-          gh issue comment "$ISSUE_NUMBER" -F .tmp_comment.txt
+          gh issue comment "$ISSUE" -F .tmp_comment.txt
 
       - name: Mark Aya request as done on blackboard
         uses: actions/github-script@v7
         env:
-          BOARD_ISSUE_NUMBER: ${{ steps.find.outputs.issue_number }}
-          COMMENT_ID: ${{ steps.find.outputs.comment_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ENTRY_JSON: ${{ steps.find.outputs.entry }}
+          ISSUE_NUMBER: ${{ steps.find.outputs.issue_number }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const issueNumber = parseInt(process.env.BOARD_ISSUE_NUMBER, 10);
-            const commentId = parseInt(process.env.COMMENT_ID || "", 10);
             const entry = JSON.parse(process.env.ENTRY_JSON || "{}");
-            if (!issueNumber || Number.isNaN(issueNumber)) {
-              core.setFailed("BOARD_ISSUE_NUMBER is missing.");
-              return;
-            }
-            if (!commentId || Number.isNaN(commentId)) {
-              core.setFailed("COMMENT_ID is missing; cannot update blackboard entry.");
-              return;
-            }
-
-            const jstIso = () => {
-              const now = new Date();
-              const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
-              return jst.toISOString().replace(/Z$/, "+09:00");
-            };
+            const issueNumber = parseInt(process.env.ISSUE_NUMBER, 10);
 
             entry.status = "done";
-            entry.updated_at = jstIso();
+            entry.updated_at = new Date().toISOString();
 
-            const body = [
+            const bodyLines = [
               "<!-- blackboard:doc_update_v1 -->",
               "",
               "json",
-              JSON.stringify(entry, null, 2),
-            ].join("\n");
+              JSON.stringify(entry, null, 2)
+            ];
+            const body = bodyLines.join("\n");
 
-            await github.rest.issues.updateComment({
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              comment_id: commentId,
-              body,
+              issue_number: issueNumber,
+              body
             });
-
-            core.info(`Updated blackboard comment ${commentId} on issue #${issueNumber} to status=done`);


### PR DESCRIPTION
Overwrite info_network_build_aya workflow with a doc_update-style implementation that is valid YAML, uses env for BOARD_ISSUE_NUMBER/PROJECT_ID, robustly parses blackboard JSON, calls OpenAI via github-script, and posts/marks Aya info_network_build_request_v1 entries.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

