### PR TITLE
Fix: remove duplicate core declaration in Info Network Build (Aya)

### DIFF
--- a/.github/workflows/info_network_build_aya.yml
+++ b/.github/workflows/info_network_build_aya.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const core = require("@actions/core");
+            // core is provided by github-script; no need to require("@actions/core")
             const issueNumber = parseInt(process.env.BOARD_ISSUE_NUMBER, 10);
             const projectId = process.env.PROJECT_ID;
 
@@ -113,7 +113,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require("fs");
-            const core = require("@actions/core");
+            // core is provided by github-script; no need to require("@actions/core")
 
             const entry = JSON.parse(process.env.ENTRY_JSON || "{}");
             const projectId = process.env.PROJECT_ID || "vpm-mini";


### PR DESCRIPTION
Remove 'const core = require("@actions/core")' from the github-script step to avoid 'Identifier core has already been declared' and allow the workflow to run normally.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

