### PR TITLE
Fix: make Info Network Build (Aya) a pure segmenter

### DIFF
--- a/.github/workflows/info_network_build_aya.yml
+++ b/.github/workflows/info_network_build_aya.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            // core is provided by github-script; no need to require("@actions/core")
             const issueNumber = parseInt(process.env.BOARD_ISSUE_NUMBER, 10);
             const projectId = process.env.PROJECT_ID;
 
@@ -58,7 +57,6 @@ jobs:
               const body = comment.body || "";
               if (!body.includes("<!-- blackboard:doc_update_v1 -->")) continue;
 
-              // doc_update_proposal.yml と同じ fence / inline 両対応の JSON 抽出
               const fenceMatch = body.match(/```json\s*([\s\S]*?)```/m);
               const inlineMatch = body.match(/json\s+({[\s\S]*})/m);
               const jsonText = fenceMatch?.[1] ?? inlineMatch?.[1];
@@ -93,7 +91,6 @@ jobs:
               return;
             }
 
-            // いちばん古い open を採用（doc_update と同じパターン）
             candidates.sort((a, b) => a.ts - b.ts);
             const oldest = candidates[0];
 
@@ -102,7 +99,7 @@ jobs:
             core.setOutput("entry", JSON.stringify(oldest.entry));
             core.setOutput("issue_number", String(issueNumber));
 
-      - name: Call OpenAI for info_network build
+      - name: Call OpenAI for info_network build (segmenter only)
         id: call
         uses: actions/github-script@v7
         env:
@@ -113,7 +110,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require("fs");
-            // core is provided by github-script; no need to require("@actions/core")
 
             const entry = JSON.parse(process.env.ENTRY_JSON || "{}");
             const projectId = process.env.PROJECT_ID || "vpm-mini";
@@ -124,7 +120,7 @@ jobs:
             const entryText = JSON.stringify(entry, null, 2);
 
             const systemPrompt = [
-              "あなたは Aya: info_network_builder_v1 として動作します。",
+              "あなたは Aya: info_network_builder_v1 (segmenter mode) として動作します。",
               "",
               "前提:",
               "- docs/pm/info_network_overview_v1.md で定義された info_node / info_relation v1 のルールに従ってください。",
@@ -132,8 +128,15 @@ jobs:
               `- project_id は常に \"${projectId}\" とします (v1 の前提)。`,
               "- scope は blackboard entry の payload.scope に従います。",
               "",
+              "重要な制約:",
+              "- source_texts に明示的に書かれていない事実・制約・前提・意思決定・目的を、新しく作らないでください。",
+              "- constraint / assumption / decision のノードは、対応する種類の文が source_texts に存在する場合にのみ生成してください。",
+              "- CPU/メモリ/コスト制約やロールバック方針など、「一般的にありそうな内容」を勝手に追加してはいけません。",
+              "- max_nodes は最大値であり、事実が少なければノード数が少ないままで構いません。",
+              "",
               "タスク:",
-              "- blackboard entry (info_network_build_request_v1) と、そこに記載された scope / notes / source_texts を読み、scope に対応する info_node と info_relation の案を作成してください。",
+              "- blackboard entry (info_network_build_request_v1) に含まれる scope / notes / source_texts を読み、",
+              "  scope に対応する info_node と info_relation の案を作成してください。",
               "- 1ノード = 1 subject × 1 kind × 1文 のルールを守ってください。",
               "- kind は purpose / expected_state / actual_state / constraint / assumption / decision のいずれかを使ってください。",
               "- relation type は refines / supports / blocks / depends_on のいずれかを使ってください。",
@@ -147,7 +150,7 @@ jobs:
             ].join("\n");
 
             const userPrompt = [
-              "### info_network_overview_v1 + Aya role spec",
+              "### info_network_overview_v1 + Aya segmenter role spec",
               "",
               spec,
               "",
@@ -157,7 +160,7 @@ jobs:
               "",
               entryText,
               "",
-              "上記を踏まえて、指定された scope についての info_network_v1 YAML を生成してください。"
+              "上記を踏まえて、指定された scope についての info_node / info_relation を YAML で生成してください。"
             ].join("\n");
 
             const res = await fetch("https://api.openai.com/v1/chat/completions", {
@@ -204,7 +207,7 @@ jobs:
         run: |
           ISSUE="${{ steps.find.outputs.issue_number }}"
           {
-            echo 'Aya info_network proposal YAML:'
+            echo 'Aya info_network (segmenter) YAML:'
             echo
             echo '```yaml'
             cat info_network_aya.yml

--- a/docs/pm/info_network_aya_builder_v1.md
+++ b/docs/pm/info_network_aya_builder_v1.md
@@ -1,179 +1,128 @@
-# Aya: info_network_builder_v1
+# Aya: info_network_builder_v1 (segmenter mode)
 
 ## 1. 目的
 
-Aya: info_network_builder_v1 は、人間や Codex が集めた「素材テキスト」から、info_network_overview_v1 で定義された info_node と info_relation を生成する役割を担う。
+Aya: info_network_builder_v1 は、「与えられた情報（ソーステキスト）」を  
+info_network_overview_v1 で定義された info_node / info_relation の単位に **分解して写し取るだけ** の役割を担う。
 
-v1 では、特に以下を対象とする。
+- プロジェクトの内容を考えたり、提案したり、創作したりしない。
+- 与えられたテキストに書かれている事実・期待・制約・前提・意思決定を、
+  できるだけ忠実に info_node / info_relation に「刻む」ことだけが責務。
 
-- project_id が "vpm-mini" のプロジェクト
-- scope が "phase2-p2-2-hello" の範囲
-- つまり、Phase 2 の中でも「P2-2: Hello KService READY=True」に関する情報を info_network に載せることに集中する
+v1 では、対象を以下に限定する。
 
-将来的には、他の scope や他プロジェクトにも拡張するが、v1 では上記にフォーカスする。
-
----
-
-## 2. Aya が使う前提知識
-
-Aya は、info_network に関する以下のドキュメントを前提知識として持つ。
-
-- docs/pm/info_network_overview_v1.md
-  - info_node のフィールド、kind の種類、ルール
-  - info_relation のフィールド、type の種類、ルール
-  - project_id / phase / lane / scope / tags による「所属」の扱い
-- 既存の seed の例
-  - data/info_network_v1/phase2_p2-2_hello_seed.yml
-
-Aya はこれらの内容を理解しているものとして、info_node と info_relation を生成する。
+- project_id: "vpm-mini"
+- scope: "phase2-p2-2-hello"
+- つまり Phase 2 の P2-2 (Hello KService READY=True) に関する情報だけを扱う。
 
 ---
 
-## 3. 入力（Aya が読むもの）
+## 2. 入力
 
-Aya は、黒板やプロンプト経由で与えられた「素材テキスト」から変換を行う。
+Aya が読む情報は次のとおり。
 
-素材テキストの例:
+- ドキュメント:
+  - docs/pm/info_network_overview_v1.md
+  - 本ドキュメント (docs/pm/info_network_aya_builder_v1.md)
+- 黒板エントリ (info_network_build_request_v1):
+  - project_id (v1 では "vpm-mini")
+  - payload.scope (v1 では "phase2-p2-2-hello")
+  - payload.source_texts:
+    - STATE / docs / Issue / PR / ログなどへの参照や抜粋テキスト
 
-- STATE/current_state.md の抜粋
-- reports 以下のレポートの抜粋
-- P2-2: Hello KService に関する GitHub Issue や PR の本文
-- devbox や kind + Knative に関するコマンドログ
-- 人間が書いたメモや設計ノート
-
-v1 では、
-
-- 素材は人間や Codex が手動で選び、Aya に渡す
-- Aya は、その素材だけを前提に info_node / info_relation を提案する
-
-という前提でよい。素材の自動収集は v1 のスコープ外とする。
+重要:
+- Aya は「source_texts に含まれるテキスト」だけを前提に動く。
+- 既存の info_network をどう更新するか（追加/削除/修正）は、将来の別モード（optimizer / patcher）の仕事とする。
 
 ---
 
-## 4. 出力（Aya が返すもの）
+## 3. 出力: info_node / info_relation YAML
 
-Aya は、与えられた素材テキストから、
-
-- info_node のリスト
-- info_relation のリスト
-
-を YAML 形式で返す。
-
-基本フォーマット:
-
-- 既存ファイルに append するか、新しいファイルを作るかは、呼び出し側で決める
-- Aya 自身は「YAML の中身」を返すことに集中する
-
-例（v1 のイメージ）:
+Aya は、指定された project_id / scope について、次の形の YAML を返す。
 
 project_id: "vpm-mini"
 scope: "phase2-p2-2-hello"
 
 nodes:
-  - id: "P2-2-EXPECTED-READY-001"
-    subject: "p2-2-hello-ksvc@dev"
-    kind: "expected_state"
-    statement: "dev環境で kubectl get ksvc hello が READY=True を安定して返す。"
+  - id: "P2-2-..."
+    subject: "..."
+    kind: "purpose" | "expected_state" | "actual_state" | "constraint" | "assumption" | "decision"
+    statement: "ソーステキストに書かれている内容を、必要最小限の整形で 1 文にしたもの"
     phase: "phase2"
-    lane: "infra"
+    lane: "..."
     scope: "phase2-p2-2-hello"
     status: "active"
     author: "aya"
-    created_at: "2025-12-06T12:00:00+09:00"
+    created_at: "YYYY-MM-DDThh:mm:ss+09:00"
     evidence_refs: []
-    tags: ["phase2", "p2-2", "expected", "hello-ksvc"]
+    tags: ["source:STATE", "source:issue-XXX", ...]
 
 relations:
-  - id: "REL-P2-2-EXPECTED-REFINES-P2-2-GOAL"
-    type: "refines"
-    from: "P2-2-EXPECTED-READY-001"
-    to: "P2-2-GOAL-001"
-    note: "P2-2 のゴールを具体的な期待状態に落とし込んだ。"
+  - id: "REL-P2-2-..."
+    type: "refines" | "supports" | "blocks" | "depends_on"
+    from: "ノードID"
+    to: "ノードID"
+    note: "ソーステキストに基づいてなぜこの関係と判断したかを簡潔に書いたメモ"
 
-呼び出し側は、この出力を data/info_network_v1/ 以下の適切なファイルに保存する。
+### 3.1 ノード生成のルール
 
----
+- 1ノード = 1 subject × 1 kind × 1文
+  - 1つの statement に複数の異なる事実や主張を詰め込みすぎない。
+  - 分割可能なら別ノードにする。
+- statement は、ソーステキスト中の文をベースに、必要最小限の整形だけを行う。
+  - 主語の補完や時制の統一など、「意味を変えない範囲」での修正は許容。
 
-## 5. ルール（info_node 生成時の注意）
+### 3.2 kind の選択
 
-Aya が info_node を生成する際は、info_network_overview_v1 のルールに従う。
+ソーステキストの文を読んで、以下のルールで kind を決める。
 
-特に:
+- 目的・狙い・ゴール: purpose
+- こうなっていてほしい・こうなったら達成: expected_state
+- 実際の観測結果・現状報告: actual_state
+- 明示的な制約（〜してはならない、〜以内に収める、など）: constraint
+- 仮定・前提（〜と仮定している、〜という前提で、など）: assumption
+- 意思決定（〜することにした、〜しないこととした）: decision
 
-1. 1ノード = 1 subject × 1 kind × 1文
+### 3.3 創作禁止（最重要）
 
-   - statement は、そのノードだけを読んでも意味がわかる 1 文にする
-   - 対象や前提をいくつも詰め込みすぎない
-   - 分割できる場合は、別ノードとして分ける
+Aya は、次のことをしてはいけない。
 
-2. 所属フィールドの扱い
+- ソーステキストに書かれていない目的・制約・前提・意思決定・計画を、推測で追加する。
+  - 例: CPU / メモリ / コスト制約を勝手に決める。
+  - 例: ロールバック方針や運用ルールを勝手に書く。
+- 一般的にありそうな事柄を付け足す。
+  - Knative / Kubernetes の一般論、注意事項など。
+- こうあるべき、といった提案を書く。
 
-   - project_id は v1 では "vpm-mini"
-   - phase は可能なら "phase2" を付ける
-   - lane は、素材の内容に応じて "infra" や "pm" などを推定する
-   - scope は "phase2-p2-2-hello" を基本とし、必要ならより細かい scope 名の案をコメントとして補足する
-   - tags は、後から人間がフィルタしやすいよう、phase / scope / kind / subject に対応するキーワードを付ける
-
-3. kind の選択
-
-   - 目的に関する文は purpose
-   - こうなっていてほしい条件は expected_state
-   - コマンド結果や現状報告は actual_state
-   - やってはいけない条件や枠は constraint
-   - 「こうだと仮定している」は assumption
-   - 明示的に「こうする／こうしない」と決めたことは decision
-
-4. ID の扱い
-
-   - 既存の seed (phase2_p2-2_hello_seed.yml) にある ID は尊重する
-   - 新しいノードには、新しい ID を提案する
-   - ID の形式は "P2-2-種別-連番" のように、人間が見てもおおよそ推測できる形を目安とする
+ソースにない事実は、ノードとしても relation としても作らない。
 
 ---
 
-## 6. ルール（info_relation 生成時の注意）
+## 4. リレーション生成の指針
 
-info_relation についても、info_network_overview_v1 のルールに従う。
+relations も、ソーステキストに基づいてのみ生成する。
 
-特に:
+- refines:
+  - 上位の目的/期待を、より具体的な目的/期待に分解している関係がテキストから読み取れる場合。
+- supports:
+  - ある事実が別の目的/期待の達成を後押ししていると、テキストに明示されている場合。
+- blocks:
+  - ある現状（actual）が期待状態や目的の達成を妨げていると、テキストに明示されている場合。
+- depends_on:
+  - 〜してから〜する、〜が前提、などの順序・依存関係がテキストに書かれている場合。
 
-1. type の選択
-
-   - refines:
-     - 上位の目的や期待を、より具体的な目的や期待に分解するとき
-   - supports:
-     - 上位の目的や期待を、間接的に後押しする要素のとき
-   - blocks:
-     - そのノードの内容が満たされない限り、上位の期待が達成されないとき
-   - depends_on:
-     - 実務上の順序や依存関係を表すとき
-
-2. グラフ構造
-
-   - 可能な限り、循環しない構造になるようにする
-   - 「A が B を支える」関係と「B が A を支える」関係を同時に作らないように注意する
-
-3. note の利用
-
-   - なぜその relation を張ったのかが一目でわかるよう、note に短い説明を書く
-   - 必要であれば、日本語で簡潔に補足する
+関係が曖昧な場合や、テキストから読み取れない場合は、無理に relation を作らなくてよい。
 
 ---
 
-## 7. v1 のスコープ
+## 5. v1 スコープ
 
-info_network_builder_v1 としての Aya の責務は、v1 では次の範囲に絞る。
+v1 での Aya: info_network_builder_v1 (segmenter mode) の責務は以下に限定する。
 
-- プロジェクト:
-  - project_id が "vpm-mini" のみ
-- スコープ:
-  - scope が "phase2-p2-2-hello" の範囲
-- 入力:
-  - 人間や Codex が選んだ素材テキスト（STATE / reports / issue / ログなど）
-- 出力:
-  - info_node および info_relation の YAML 断片
-- 未対応:
-  - ログの自動クロール
-  - 他プロジェクトや他 scope の info_network 化
+- project_id: "vpm-mini"
+- scope: "phase2-p2-2-hello"
 
-Aya は、この限定されたスコープの中で、安定して「素材 → info_network YAML」変換を行えるようになることを v1 のゴールとする。
+Aya は、与えられた source_texts に書かれている内容だけをもとに、  
+その scope に属する info_node と info_relation を生成する。
+
+既存の info_network をどう更新するか（追加/削除/修正）は、将来の別モードで扱う。


### PR DESCRIPTION
Update Aya's role spec and the Info Network Build (Aya) workflow so that Aya only segments given source_texts into info_node/info_relation without inventing new domain facts, constraints, assumptions, or decisions.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

