### PR TITLE
Chore: clarify refines direction and decision usage for Aya segmenter

### DIFF
--- a/.github/workflows/info_network_build_aya.yml
+++ b/.github/workflows/info_network_build_aya.yml
@@ -133,6 +133,8 @@ jobs:
               "- constraint / assumption / decision のノードは、対応する種類の文が source_texts に存在する場合にのみ生成してください。",
               "- CPU/メモリ/コスト制約やロールバック方針など、「一般的にありそうな内容」を勝手に追加してはいけません。",
               "- max_nodes は最大値であり、事実が少なければノード数が少ないままで構いません。",
+              "- refines の relation は、常により具体的なノード（子）からより抽象的なノード（親）へ向かって張ってください（expected_state から purpose へなど）。",
+              "- decision ノードは、明確な意思決定（〜することにした、〜しないこととした）の文が source_texts に存在する場合にのみ生成し、Issue 番号との紐付けは tags や evidence_refs で表現してください。",
               "",
               "タスク:",
               "- blackboard entry (info_network_build_request_v1) に含まれる scope / notes / source_texts を読み、",

--- a/docs/pm/info_network_aya_builder_v1.md
+++ b/docs/pm/info_network_aya_builder_v1.md
@@ -83,7 +83,15 @@ relations:
 - 仮定・前提（〜と仮定している、〜という前提で、など）: assumption
 - 意思決定（〜することにした、〜しないこととした）: decision
 
-### 3.3 創作禁止（最重要）
+### 3.3 refines の向きについて
+
+expected_state と purpose の関係を表現するときは、expected_state ノードが purpose ノードを refines するように relation を張る（from=expected_state, to=purpose）。
+
+### 3.4 decision の使いどころ
+
+decision は「方針・設計・運用レベルの意思決定」を表す場合にのみ使う。単に「Issue #XXX で管理する」「この Issue で扱う」といった管理メモは decision ではなく、tags や evidence_refs で表現する。
+
+### 3.5 創作禁止（最重要）
 
 Aya は、次のことをしてはいけない。
 

--- a/docs/pm/info_network_overview_v1.md
+++ b/docs/pm/info_network_overview_v1.md
@@ -212,6 +212,7 @@ v1では、代表的な 4 種を用意する：
 
 - `refines`  
   - 上位の目的/期待を、より具体的な目的/期待に分解する。
+  - relation の向きは「より具体的なノード（子）」→「より抽象的なノード（親）」とし、例として expected_state が purpose を refines する場合は `from=expected_state`, `to=purpose` とする。
 
 - `supports`  
   - 上位の目的/期待の達成に「寄与する」（あれば嬉しい・進みやすくなる）。


### PR DESCRIPTION
Update info_network_overview_v1 and Aya segmenter role spec to clarify refines direction (expected_state -> purpose) and restrict decision nodes to real decisions, and reflect these rules in the Info Network Build (Aya) workflow system prompt.

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

