### PR TITLE
docs(ops): ops templates v1 (handoff + bundles)

### DIFF
--- a/docs/ops/templates/README.md
+++ b/docs/ops/templates/README.md
@@ -1,0 +1,16 @@
+# Ops Templates Index (v1)
+
+このフォルダは「VPM運用OSの型」をコピペして使うためのテンプレ集です。
+
+## 使い方（最短）
+1. テンプレをコピーして docs に 1ページを作る（handoff / playbook など）
+2. そのページの存在を Project Lane（黒板）に DocPointer として登録する（memo bundle → merge runner）
+
+## テンプレ一覧
+- Handoff:
+  - docs/ops/templates/handoff_template_v1.md
+- Bundle templates（memo）:
+  - templates/bundles/docpointer_update_bundle_template.yaml
+  - templates/bundles/progress_update_bundle_template.yaml
+- Playbooks:
+  - （次PRで追加）multi_pr_same_ssot_playbook_v1.md

--- a/docs/ops/templates/handoff_template_v1.md
+++ b/docs/ops/templates/handoff_template_v1.md
@@ -1,0 +1,32 @@
+# Project Handoff Template v1
+
+## Context
+- repo:
+- branch:
+- project_id:
+- lane: Project Lane (B) / Domain Lane (A)
+
+## What is this project?
+- goal:
+- non-goals:
+- current phase:
+
+## Current status (SSOT pointers)
+- Project Lane SSOT:
+  - data/{project_id}/info_nodes_v1.json
+  - data/{project_id}/info_relations_v1.json
+- Key docs (DocPointers):
+  - (path or url)
+
+## What changed recently
+- PRs / Issues:
+- decisions made:
+
+## Next actions (1-3)
+- 1)
+- 2)
+- 3)
+
+## Risks / gotchas
+- token / CI / required checks:
+- naming constraints:

--- a/templates/bundles/docpointer_update_bundle_template.yaml
+++ b/templates/bundles/docpointer_update_bundle_template.yaml
@@ -1,0 +1,23 @@
+info_source_bundle_v1:
+  project_id: "__PROJECT_ID__"
+  source_type: "memo"
+  source_id: "docpointer_update_YYYY-MM-DD"
+  title: "DocPointer Update: __TITLE__"
+  time_range:
+    from: "YYYY-MM-DD"
+    to: "YYYY-MM-DD"
+  raw_text: |
+    doc_id: __DOC_ID__
+    title: __DOC_TITLE__
+    location:
+      path: docs/...  # or url: https://...
+    role: "__ROLE__"  # handoff/spec/playbook/how-to
+    when_to_consult:
+      - "__WHEN__"
+    update_triggers:
+      - "__TRIGGER__"
+  hints:
+    - "Project Lane（黒板）へのDocPointer登録。本文はdocs側に置き、黒板にはポインタ情報だけを残す。"
+  tags:
+    - "kind:memo"
+    - "kind:docpointer"

--- a/templates/bundles/progress_update_bundle_template.yaml
+++ b/templates/bundles/progress_update_bundle_template.yaml
@@ -1,0 +1,22 @@
+info_source_bundle_v1:
+  project_id: "__PROJECT_ID__"
+  source_type: "memo"
+  source_id: "progress_update_YYYY-MM-DD"
+  title: "Progress Update: __TITLE__"
+  time_range:
+    from: "YYYY-MM-DD"
+    to: "YYYY-MM-DD"
+  raw_text: |
+    What happened:
+    - __SUMMARY__
+
+    Decisions:
+    - __DECISION__
+
+    Tasks/Gaps:
+    - __TASK_OR_GAP__
+  hints:
+    - "Project Lane（黒板）の進捗更新。短く、decision/task/gap の要点に落とす。"
+  tags:
+    - "kind:memo"
+    - "kind:progress"


### PR DESCRIPTION
Closes #982

Summary:
- Added ops templates index
- Added handoff template
- Added memo bundle templates for DocPointer Update and Progress Update

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

