### PR TITLE
docs(ops): playbook + bundle guide v1

### DIFF
--- a/docs/ops/multi_pr_same_ssot_playbook_v1.md
+++ b/docs/ops/multi_pr_same_ssot_playbook_v1.md
@@ -1,0 +1,19 @@
+# Multi-PR on same SSOT playbook v1
+
+同一SSOT（例：data/{project_id}/info_nodes_v1.json）を複数PRで並行更新する際の運用。
+
+## 原則
+- 同じファイルを複数PRで触るなら、先行PRを先にマージする
+- 後続PRは origin/main を取り込んでから（rebase推奨）マージする
+- 競合が出たら「どちらが最新の決定か」「重複decisionはdropか」を先に判断して解消
+
+## 推奨フロー
+1. PR-A を先にマージ
+2. PR-B のブランチで main 追随
+   - git fetch origin --prune
+   - git rebase origin/main
+3. CIが通ることを確認して PR-B をマージ
+
+## よくある事故と回避
+- required checks が Expected のまま：PR作成がGITHUB_TOKEN起点 → PAT（PR_BOT_TOKEN）推奨
+- run intermediates をコミット：runner/.gitignoreで防止（#977）

--- a/docs/ops/project_lane_bundle_templates_v1.md
+++ b/docs/ops/project_lane_bundle_templates_v1.md
@@ -1,0 +1,32 @@
+# Project Lane bundle templates v1
+
+このドキュメントは Project Lane（黒板SSOT）を更新するための memo bundle テンプレの使い方です。
+
+対象SSOT:
+- data/{project_id}/info_nodes_v1.json
+- data/{project_id}/info_relations_v1.json
+
+## 作業タイプ
+- DocPointer Update: docs/外部URLの「存在・役割・参照先」を黒板に登録する
+- Progress Update: 進捗・決定・障害・解決策を黒板に反映する
+
+## テンプレ
+- templates/bundles/docpointer_update_bundle_template.yaml
+- templates/bundles/progress_update_bundle_template.yaml
+
+## 標準実行（merge runner）
+基本は runner で PR まで作る。
+
+```bash
+export PR_BOT_TOKEN=...  # 推奨
+scripts/info_network/merge_run_v1.sh --project-id {project_id} --bundle <bundle.yaml> --mode pr --policy additive_only
+```
+
+- questions が出たら止まる（人間が判断して再実行）
+- additive_only を基本にする（supersede/obsoleteで過去方針を壊しにくい）
+- run intermediates（snapshot/seed/suggestion）は追跡しない（runnerと.gitignoreが担保）
+
+## DoD
+- PRが作られ、CIが通り、mainにマージされる
+- 黒板SSOTが更新される
+- run artifacts として approved_plan.json と bundle が残る


### PR DESCRIPTION
Refs #982

Summary:
- Added Project Lane bundle templates guide
- Added playbook for multi-PR updates to same SSOT files

## Audit Links
- PROV: (none)
- Dashboards:
  - Phase-1 KPI:  http://grafana.monitoring.svc.cluster.local/d/phase1_kpi
  - Chaos Audit:  http://grafana.monitoring.svc.cluster.local/d/chaos_audit
- Evidence (this PR):
(none)

